### PR TITLE
docs: track CLAUDE.md and add Claude Code badge to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,6 @@ bridge/package-lock.json
 package/MaxMCP/externals/*.mxo
 package/MaxMCP/support/maxmcp-bridge
 
-# Claude Code / AI assistant configs (not tracked)
-CLAUDE.md
+# Claude Code / AI assistant local configs (not tracked)
 .claude/
 *.local.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MaxMCP - Native MCP Server for Max/MSP
 
+[![Developed with Claude Code](https://img.shields.io/badge/Developed%20with-Claude%20Code-blueviolet)](https://claude.ai/code)
+
 Control your Max/MSP patches with Claude Code using natural language.
 
 ## Overview
@@ -259,6 +261,8 @@ We welcome contributions from the community! Please see:
 - [CONTRIBUTING.md](CONTRIBUTING.md) - How to contribute
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) - Community guidelines
 - [SECURITY.md](SECURITY.md) - Security policy
+
+This project uses [Claude Code](https://claude.ai/code) for development. See [CLAUDE.md](CLAUDE.md) for AI assistant guidelines and project conventions.
 
 All contributions are automatically validated by CI to ensure code quality and test coverage.
 


### PR DESCRIPTION
## Summary

- Track `CLAUDE.md` as project documentation (removed from .gitignore)
- Update `CLAUDE.md` with GitHub Flow and Release Please documentation
- Add Claude Code badge to README header
- Add Claude Code reference in Contributing section

## Changes

### .gitignore
- Remove `CLAUDE.md` from ignore list
- Keep `.claude/` and `*.local.md` ignored (local/personal data)

### CLAUDE.md
- Update Git Workflow from Git Flow to GitHub Flow
- Add Release Management section documenting Release Please

### README.md
- Add "Developed with Claude Code" badge at the top
- Add reference to CLAUDE.md in Contributing section

## Rationale

`CLAUDE.md` contains project-specific guidelines that benefit all contributors using Claude Code:
- Build commands and testing instructions
- Architecture overview
- Git workflow and conventions
- Release management

This is essentially developer documentation and should be shared.

## Test plan

- [ ] Badge displays correctly on GitHub README
- [ ] CLAUDE.md link works in Contributing section
- [ ] CI passes
