### PR TITLE
fix: add last-release-sha to sync Release Please state

### DIFF
--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -129,6 +129,71 @@ Runs when a GitHub Release is published:
 
 ---
 
+## ⚠️ Critical Rules
+
+### DO NOT
+
+| Action | Why |
+|--------|-----|
+| Create tags manually (`git tag`) | Breaks Release Please's version tracking |
+| Edit CHANGELOG.md manually | Release Please manages this automatically |
+| Manually bump version numbers | Conventional Commits control versioning |
+| Ignore Release Please PRs | They must be merged to sync state |
+
+### ALWAYS
+
+| Action | Why |
+|--------|-----|
+| Merge Release Please PRs promptly | Keeps version state synchronized |
+| Use Conventional Commits | Determines version bumps automatically |
+| Let Release Please create tags | Ensures proper release tracking |
+
+---
+
+## Troubleshooting
+
+### Stale Release PR (version mismatch)
+
+**Symptom**: Release Please PR shows old version (e.g., `release 1.0.0`) but tags already exist (e.g., `v1.1.1`).
+
+**Cause**: Tags were created manually without merging Release Please PRs. Release Please tracks state via merged Release PRs, not git tags.
+
+**Fix**:
+
+1. Get the commit SHA of the latest tag:
+   ```bash
+   git rev-parse v1.1.1
+   ```
+
+2. Add `last-release-sha` to `release-please-config.json`:
+   ```json
+   {
+     "last-release-sha": "<full-sha-from-step-1>",
+     ...
+   }
+   ```
+
+3. Update `.release-please-manifest.json` to match the tag version:
+   ```json
+   {
+     ".": "1.1.1"
+   }
+   ```
+
+4. Close the stale Release PR.
+
+5. Merge the fix to main. Release Please will now create new PRs based on the correct version.
+
+6. **Important**: Remove `last-release-sha` after a successful Release PR is merged.
+
+### Release Please not creating PRs
+
+**Cause**: No releasable commits since last release. Only `feat:`, `fix:`, `perf:`, and breaking changes trigger releases.
+
+**Fix**: Ensure commits use Conventional Commits format with releasable types.
+
+---
+
 ## Manual Release (Emergency Only)
 
 In rare cases where automation fails:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "137e4c97319efb3ff67f840ab080da0328061d14",
   "release-type": "simple",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
## Summary

- Add `last-release-sha` pointing to v1.1.1 tag commit
- Document critical rules for Release Please workflow
- Add troubleshooting guide for stale Release PR issues

## Problem

Release Please PRs were not being merged, causing version mismatch:
- Manifest: `1.0.0`
- Git tags: `v1.0.0`, `v1.0.1`, `v1.1.0`, `v1.1.1`

Release Please tracks state via merged Release PRs, not git tags. Since no Release PR was ever merged, it kept creating `release 1.0.0` PRs.

## Solution

1. Added `last-release-sha` to tell Release Please to start from v1.1.1
2. Documented critical rules to prevent this issue in the future
3. Added troubleshooting guide for similar issues

## After Merge

1. Close stale PR #13
2. After a successful Release PR is merged, remove `last-release-sha` from config

---

🤖 Generated with [Claude Code](https://claude.ai/code)