### PR TITLE
fix(tools): add newline character escape in add_max_object

### DIFF
--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -157,6 +157,17 @@ static void add_object_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_atom*
         pos += 2;
     }
 
+    // 4. Replace newline characters with space (prevents @text attribute issues)
+    pos = 0;
+    while ((pos = escaped.find('\n', pos)) != std::string::npos) {
+        escaped.replace(pos, 1, " ");
+        pos += 1;
+    }
+    pos = 0;
+    while ((pos = escaped.find('\r', pos)) != std::string::npos) {
+        escaped.erase(pos, 1);
+    }
+
     // Create object with newobject_sprintf (without size - use Max default)
     t_object* obj = (t_object*)newobject_sprintf(
         data->patch->patcher, "@maxclass newobj @text \"%s\" @patching_position %.2f %.2f",


### PR DESCRIPTION
## Summary

- Replace `\n` with space in object text
- Remove `\r` to prevent @text attribute parsing issues

## Related Issue

Part of #12

## Test Plan

- [ ] Verify objects with newline characters in arguments are created correctly
- [ ] Verify no regression in existing escape handling

---

🤖 Generated with [Claude Code](https://claude.ai/code)