### PR TITLE
fix(ci): trigger release-assets workflow via workflow_dispatch

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -51,19 +51,47 @@ jobs:
           INPUT_TAG_NAME: ${{ inputs.tag_name }}
         with:
           script: |
-            const release = await github.rest.repos.getReleaseByTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: process.env.INPUT_TAG_NAME
-            });
-            core.setOutput('upload_url', release.data.upload_url);
+            const tagName = process.env.INPUT_TAG_NAME;
+
+            if (!tagName) {
+              core.setFailed('INPUT_TAG_NAME is not set');
+              return;
+            }
+
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName
+              });
+              core.setOutput('upload_url', release.data.upload_url);
+              console.log(`Found release for tag ${tagName}`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.setFailed(`Release not found for tag '${tagName}'`);
+              } else {
+                core.setFailed(`Failed to get release: ${error.message}`);
+              }
+              return;
+            }
+
+      - name: Validate upload URL
+        if: ${{ inputs.tag_name && success() }}
+        env:
+          UPLOAD_URL: ${{ steps.get_release.outputs.upload_url }}
+        run: |
+          if [ -z "$UPLOAD_URL" ]; then
+            echo "::error::Upload URL is empty. The get_release step may have failed."
+            exit 1
+          fi
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPLOAD_URL: ${{ steps.get_release.outputs.upload_url || github.event.release.upload_url }}
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url || github.event.release.upload_url }}
+          upload_url: ${{ env.UPLOAD_URL }}
           asset_path: package/MaxMCP-${{ env.TAG_NAME }}-macos-arm64.zip
           asset_name: MaxMCP-${{ env.TAG_NAME }}-macos-arm64.zip
           asset_content_type: application/zip
@@ -77,8 +105,9 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPLOAD_URL: ${{ steps.get_release.outputs.upload_url || github.event.release.upload_url }}
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url || github.event.release.upload_url }}
+          upload_url: ${{ env.UPLOAD_URL }}
           asset_path: package/checksums.txt
           asset_name: checksums.txt
           asset_content_type: text/plain

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,13 +33,30 @@ jobs:
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         with:
           script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'release-assets.yml',
-              ref: 'main',
-              inputs: {
-                tag_name: process.env.TAG_NAME
+            const tagName = process.env.TAG_NAME;
+
+            if (!tagName || tagName.trim() === '') {
+              core.setFailed('TAG_NAME is empty. Release Please may not have created a release.');
+              return;
+            }
+
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'release-assets.yml',
+                ref: 'main',
+                inputs: {
+                  tag_name: tagName
+                }
+              });
+              console.log(`Triggered release-assets workflow for tag: ${tagName}`);
+              console.log(`Check: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/release-assets.yml`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.setFailed(`Workflow 'release-assets.yml' not found`);
+              } else {
+                core.setFailed(`Failed to trigger workflow: ${error.message}`);
               }
-            });
-            console.log(`Triggered release-assets workflow for tag: ${process.env.TAG_NAME}`);
+              return;
+            }


### PR DESCRIPTION
## Summary
- Fix release-assets workflow not triggering when Release Please creates a release
- GITHUB_TOKEN-generated releases don't fire `on: release: published` events
- Use workflow_dispatch to explicitly trigger asset builds after release creation

## Changes
- Add `workflow_dispatch` trigger to `release-assets.yml` with `tag_name` input
- Add `trigger-assets` job to `release-please.yml` that calls release-assets after release creation
- Use environment variables for secure tag name handling in github-script

## Test plan
- [ ] Merge this PR
- [ ] Wait for Release Please to create a release PR
- [ ] Merge the release PR
- [ ] Verify `release-assets.yml` is triggered via workflow_dispatch
- [ ] Verify assets are attached to the GitHub Release

## References
- [googleapis/release-please-action#1000](https://github.com/googleapis/release-please-action/issues/1000)

🤖 Generated with [Claude Code](https://claude.ai/code)