### PR TITLE
fix(ci): add Max SDK clone step to release-assets workflow

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -22,6 +22,12 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.tag_name || github.event.release.tag_name }}
 
+      - name: Clone Max SDK
+        run: |
+          git clone --depth 1 https://github.com/Cycling74/max-sdk.git max-sdk
+          cd max-sdk
+          git submodule update --init --recursive --depth 1
+
       - name: Install dependencies
         run: |
           brew install cmake nlohmann-json libwebsockets


### PR DESCRIPTION
## Summary
- release-assetsワークフローでCMake設定が失敗していた問題を修正
- CI.ymlと同様にMax SDKをcloneするステップを追加

## 原因
release-assets.ymlにMax SDKのcloneステップがなく、CMakeがMax SDKを見つけられなかった。

## 修正内容
```yaml
- name: Clone Max SDK
  run: |
    git clone --depth 1 https://github.com/Cycling74/max-sdk.git max-sdk
    cd max-sdk
    git submodule update --init --recursive --depth 1
```

## テスト
PRマージ後、手動で `gh workflow run release-assets.yml -f tag_name=v1.0.1` を実行して検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)