### PR TITLE
docs: add MCP integration test checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ cmake --install build --prefix package/MaxMCP
 **Test framework**: Google Test 1.17.0
 **Test files**: `tests/unit/test_*.cpp`
 **Test mode macro**: `MAXMCP_TEST_MODE` (enables compilation without Max SDK)
+**Integration test checklist**: [docs/integration-test-checklist.md](docs/integration-test-checklist.md) (MCP全26ツールの実機テスト用)
 
 ## Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ cmake --install build --prefix package/MaxMCP
 **Test framework**: Google Test 1.17.0
 **Test files**: `tests/unit/test_*.cpp`
 **Test mode macro**: `MAXMCP_TEST_MODE` (enables compilation without Max SDK)
-**Integration test checklist**: [docs/integration-test-checklist.md](docs/integration-test-checklist.md) (MCP全26ツールの実機テスト用)
+**Integration test checklist**: [docs/integration-test-checklist.md](docs/integration-test-checklist.md) (manual verification of all 26 MCP tools)
 
 ## Code Quality
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -154,6 +154,14 @@ This index provides a comprehensive overview of all MaxMCP documentation.
 - Claude Code prompts for testing
 - Expected results and error scenarios
 
+### [Integration Test Checklist](integration-test-checklist.md)
+**Purpose**: MCP全26ツールの実機テスト用チェックリスト
+**Date**: 2026-03-09
+**Contents**:
+- 全26ツールのチェックリスト（表形式）
+- 推奨テスト手順
+- PR作成時・リリース前の確認用
+
 ---
 
 ## 📖 Additional Resources
@@ -279,6 +287,7 @@ Documentation should be updated when:
 | Check Infrastructure results | [Phase 1 Infrastructure](PHASE1_INFRASTRUCTURE.md) |
 | See version history | [CHANGELOG](../CHANGELOG.md) |
 | Find E2E test results | [E2E Test Results](e2e-test-results-phase2.md) |
+| Run integration test checklist | [Integration Test Checklist](integration-test-checklist.md) |
 | Get started as new developer | [Onboarding Guide](onboarding.md) |
 | Set up and run MaxMCP | [Server Usage Guide](server-usage.md) |
 | Understand release process | [Release Workflow](RELEASE_WORKFLOW.md) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -155,12 +155,12 @@ This index provides a comprehensive overview of all MaxMCP documentation.
 - Expected results and error scenarios
 
 ### [Integration Test Checklist](integration-test-checklist.md)
-**Purpose**: MCP全26ツールの実機テスト用チェックリスト
+**Purpose**: Manual verification checklist for all 26 MCP tools
 **Date**: 2026-03-09
 **Contents**:
-- 全26ツールのチェックリスト（表形式）
-- 推奨テスト手順
-- PR作成時・リリース前の確認用
+- Table-format checklist covering all 26 tools
+- Recommended test flow
+- For use before PR merges and releases
 
 ---
 

--- a/docs/integration-test-checklist.md
+++ b/docs/integration-test-checklist.md
@@ -1,94 +1,92 @@
 # MCP Integration Test Checklist
 
 **Total Tools**: 26
-**Purpose**: 実機テスト用チェックリスト。PR作成時やリリース前に全MCPツールの動作を確認する。
+**Purpose**: Manual verification checklist for all MCP tools. Use before PR merges and releases.
 
 ---
 
 ## Prerequisites
 
-- [ ] Max/MSP が起動している
-- [ ] `maxmcp @mode patch` を含むパッチが開かれている
-- [ ] Claude Code が MaxMCP MCP サーバーに接続されている
-- [ ] `list_active_patches` でパッチが検出される
+- [ ] Max/MSP is running
+- [ ] A patch containing `maxmcp @mode patch` is open
+- [ ] Claude Code is connected to the MaxMCP MCP server
+- [ ] `list_active_patches` detects the patch
 
 ---
 
 ## Patch Management (3)
 
-| # | Tool                  | Test                        | Expected                            | Pass |
-|---|-----------------------|-----------------------------|-------------------------------------|------|
-| 1 | `list_active_patches` | パッチ一覧を取得            | パッチが1件以上表示される           | [ ]  |
-| 2 | `get_patch_info`      | patch_id を指定して情報取得 | display_name, patcher_name 等が返る | [ ]  |
-| 3 | `get_frontmost_patch` | 最前面パッチを取得          | 現在フォーカス中のパッチ情報が返る  | [ ]  |
+| # | Tool                  | Test                          | Expected                                     | Pass |
+|---|-----------------------|-------------------------------|----------------------------------------------|------|
+| 1 | `list_active_patches` | List all patches              | At least 1 patch returned                    | [ ]  |
+| 2 | `get_patch_info`      | Query by patch_id             | Returns display_name, patcher_name, etc.     | [ ]  |
+| 3 | `get_frontmost_patch` | Get frontmost patch           | Returns currently focused patch info         | [ ]  |
 
 ## Object Operations (12)
 
-| #  | Tool                   | Test                           | Expected                              | Pass |
-|----|------------------------|--------------------------------|---------------------------------------|------|
-| 4  | `add_max_object`       | `cycle~ 440` を追加            | status: success, varname が返る       | [ ]  |
-| 5  | `remove_max_object`    | 追加したオブジェクトを削除     | status: success                       | [ ]  |
-| 6  | `get_objects_in_patch` | パッチ内オブジェクト一覧取得   | オブジェクトの配列が返る              | [ ]  |
-| 7  | `set_object_attribute` | number box の bgcolor を変更   | status: success, パッチ上で色が変わる | [ ]  |
-| 8  | `get_object_attribute` | patching_rect を取得           | [x, y, width, height] の配列が返る    | [ ]  |
-| 9  | `get_object_value`     | number box の値を取得          | 数値が返る (デフォルト: 0)            | [ ]  |
-| 10 | `get_object_io_info`   | cycle~ の IO 情報取得          | inlet_count: 2, outlet_count: 1       | [ ]  |
-| 11 | `get_object_hidden`    | 非表示状態を取得               | hidden: false (デフォルト)            | [ ]  |
-| 12 | `set_object_hidden`    | 非表示に設定→元に戻す          | hidden: true → hidden: false          | [ ]  |
-| 13 | `redraw_object`        | オブジェクトを再描画           | success: true                         | [ ]  |
-| 14 | `replace_object_text`  | `cycle~ 440` → `cycle~ 880`    | old_text/new_text が正しく返る        | [ ]  |
-| 15 | `assign_varnames`      | varname なしオブジェクトに付与 | assigned: 1, varname が設定される     | [ ]  |
+| #  | Tool                   | Test                              | Expected                                  | Pass |
+|----|------------------------|-----------------------------------|-------------------------------------------|------|
+| 4  | `add_max_object`       | Add `cycle~ 440`                  | status: success, varname returned         | [ ]  |
+| 5  | `remove_max_object`    | Remove added object               | status: success                           | [ ]  |
+| 6  | `get_objects_in_patch` | List objects in patch             | Array of objects returned                 | [ ]  |
+| 7  | `set_object_attribute` | Change bgcolor of number box      | status: success, color changes in patch   | [ ]  |
+| 8  | `get_object_attribute` | Get patching_rect                 | Returns [x, y, width, height] array       | [ ]  |
+| 9  | `get_object_value`     | Get number box value              | Returns number (default: 0)               | [ ]  |
+| 10 | `get_object_io_info`   | Get IO info for cycle~            | inlet_count: 2, outlet_count: 1           | [ ]  |
+| 11 | `get_object_hidden`    | Get hidden state                  | hidden: false (default)                   | [ ]  |
+| 12 | `set_object_hidden`    | Hide then unhide                  | hidden: true then hidden: false           | [ ]  |
+| 13 | `redraw_object`        | Force redraw                      | success: true                             | [ ]  |
+| 14 | `replace_object_text`  | Change `cycle~ 440` to `cycle~ 880` | old_text/new_text returned correctly   | [ ]  |
+| 15 | `assign_varnames`      | Assign varname to unnamed object  | assigned: 1, varname set                  | [ ]  |
 
 ## Connection Operations (4)
 
-| #  | Tool                      | Test                    | Expected                                  | Pass |
-|----|---------------------------|-------------------------|-------------------------------------------|------|
-| 16 | `connect_max_objects`     | 2つのオブジェクトを接続 | status: success, パッチコードが表示される | [ ]  |
-| 17 | `disconnect_max_objects`  | 接続を切断              | status: success, パッチコードが消える     | [ ]  |
-| 18 | `get_patchlines`          | パッチコード一覧取得    | patchlines 配列に接続情報が含まれる       | [ ]  |
-| 19 | `set_patchline_midpoints` | 中間点を設定→削除       | midpoints 設定/空配列で解除               | [ ]  |
+| #  | Tool                      | Test                       | Expected                                   | Pass |
+|----|---------------------------|----------------------------|--------------------------------------------|------|
+| 16 | `connect_max_objects`     | Connect two objects        | status: success, patchcord visible         | [ ]  |
+| 17 | `disconnect_max_objects`  | Disconnect objects         | status: success, patchcord removed         | [ ]  |
+| 18 | `get_patchlines`          | List all patchcords        | patchlines array with connection info      | [ ]  |
+| 19 | `set_patchline_midpoints` | Set then clear midpoints   | Midpoints set / cleared with empty array   | [ ]  |
 
 ## Patch State (3)
 
-| #  | Tool                   | Test                  | Expected                                    | Pass |
-|----|------------------------|-----------------------|---------------------------------------------|------|
-| 20 | `get_patch_lock_state` | ロック状態を取得      | locked: true/false が返る                   | [ ]  |
-| 21 | `set_patch_lock_state` | ロック→アンロック切替 | パッチの編集/プレゼンテーションが切り替わる | [ ]  |
-| 22 | `get_patch_dirty`      | ダーティ状態を取得    | dirty: true/false が返る                    | [ ]  |
+| #  | Tool                   | Test                    | Expected                                         | Pass |
+|----|------------------------|-------------------------|--------------------------------------------------|------|
+| 20 | `get_patch_lock_state` | Get lock state          | locked: true/false returned                      | [ ]  |
+| 21 | `set_patch_lock_state` | Toggle lock/unlock      | Patch switches between edit/presentation mode    | [ ]  |
+| 22 | `get_patch_dirty`      | Get dirty state         | dirty: true/false returned                       | [ ]  |
 
 ## Hierarchy (2)
 
-| #  | Tool                 | Test                     | Expected                           | Pass |
-|----|----------------------|--------------------------|------------------------------------|------|
-| 23 | `get_parent_patcher` | トップレベルパッチで実行 | エラー: "No parent patcher" (正常) | [ ]  |
-| 24 | `get_subpatchers`    | サブパッチャーなしで実行 | count: 0, subpatchers: []          | [ ]  |
+| #  | Tool                 | Test                        | Expected                              | Pass |
+|----|----------------------|-----------------------------|---------------------------------------|------|
+| 23 | `get_parent_patcher` | Run on top-level patch      | Error: "No parent patcher" (expected) | [ ]  |
+| 24 | `get_subpatchers`    | Run on patch with no subs   | count: 0, subpatchers: []             | [ ]  |
 
 ## Utilities (2)
 
-| # | Tool | Test | Expected | Pass |
-|---|------|------|----------|------|
-| 25 | `get_console_log` | コンソールログを取得 | ログメッセージの配列が返る | [ ] |
-| 26 | `get_avoid_rect_position` | 空き位置を取得 | 既存オブジェクトと重ならない座標が返る | [ ] |
+| #  | Tool                      | Test                    | Expected                                      | Pass |
+|----|---------------------------|-------------------------|-----------------------------------------------|------|
+| 25 | `get_console_log`         | Retrieve console log    | Array of log messages returned                | [ ]  |
+| 26 | `get_avoid_rect_position` | Find empty position     | Returns coordinates avoiding existing objects | [ ]  |
 
 ---
 
-## Test Flow (推奨手順)
+## Recommended Test Flow
 
-効率的にテストするための推奨手順:
-
-1. **接続確認**: Prerequisites の4項目を確認
-2. **オブジェクト作成**: number, cycle~, gain~, dac~ を作成 (#4)
-3. **オブジェクト操作**: 属性/値/IO/表示を確認 (#6-15)
-4. **接続操作**: オブジェクトを接続→切断 (#16-19)
-5. **パッチ状態**: ロック/ダーティ確認 (#20-22)
-6. **階層**: 親パッチャー/サブパッチャー確認 (#23-24)
-7. **ユーティリティ**: ログ/位置取得 (#25-26)
-8. **クリーンアップ**: テスト用オブジェクトを削除 (#5)
+1. **Verify connection**: Check all 4 prerequisites
+2. **Create objects**: Add number, cycle~, gain~, dac~ (#4)
+3. **Object operations**: Verify attributes, values, IO, visibility (#6-15)
+4. **Connections**: Connect and disconnect objects (#16-19)
+5. **Patch state**: Check lock/dirty state (#20-22)
+6. **Hierarchy**: Verify parent/subpatcher queries (#23-24)
+7. **Utilities**: Test log and position tools (#25-26)
+8. **Cleanup**: Remove test objects (#5)
 
 ---
 
 ## Notes
 
-- `get_parent_patcher` はトップレベルパッチに対してエラーを返すのが正常動作
-- `get_subpatchers` はサブパッチャーがなければ空配列を返すのが正常動作
-- Hierarchy の完全なテストにはサブパッチャー（p, poly~, bpatcher 等）を含むパッチが必要
+- `get_parent_patcher` returns an error on top-level patches — this is expected behavior
+- `get_subpatchers` returns an empty array when no subpatchers exist — this is expected behavior
+- Full hierarchy testing requires a patch containing subpatchers (p, poly~, bpatcher, etc.)

--- a/docs/integration-test-checklist.md
+++ b/docs/integration-test-checklist.md
@@ -1,0 +1,94 @@
+# MCP Integration Test Checklist
+
+**Total Tools**: 26
+**Purpose**: 実機テスト用チェックリスト。PR作成時やリリース前に全MCPツールの動作を確認する。
+
+---
+
+## Prerequisites
+
+- [ ] Max/MSP が起動している
+- [ ] `maxmcp @mode patch` を含むパッチが開かれている
+- [ ] Claude Code が MaxMCP MCP サーバーに接続されている
+- [ ] `list_active_patches` でパッチが検出される
+
+---
+
+## Patch Management (3)
+
+| # | Tool                  | Test                        | Expected                            | Pass |
+|---|-----------------------|-----------------------------|-------------------------------------|------|
+| 1 | `list_active_patches` | パッチ一覧を取得            | パッチが1件以上表示される           | [ ]  |
+| 2 | `get_patch_info`      | patch_id を指定して情報取得 | display_name, patcher_name 等が返る | [ ]  |
+| 3 | `get_frontmost_patch` | 最前面パッチを取得          | 現在フォーカス中のパッチ情報が返る  | [ ]  |
+
+## Object Operations (12)
+
+| #  | Tool                   | Test                           | Expected                              | Pass |
+|----|------------------------|--------------------------------|---------------------------------------|------|
+| 4  | `add_max_object`       | `cycle~ 440` を追加            | status: success, varname が返る       | [ ]  |
+| 5  | `remove_max_object`    | 追加したオブジェクトを削除     | status: success                       | [ ]  |
+| 6  | `get_objects_in_patch` | パッチ内オブジェクト一覧取得   | オブジェクトの配列が返る              | [ ]  |
+| 7  | `set_object_attribute` | number box の bgcolor を変更   | status: success, パッチ上で色が変わる | [ ]  |
+| 8  | `get_object_attribute` | patching_rect を取得           | [x, y, width, height] の配列が返る    | [ ]  |
+| 9  | `get_object_value`     | number box の値を取得          | 数値が返る (デフォルト: 0)            | [ ]  |
+| 10 | `get_object_io_info`   | cycle~ の IO 情報取得          | inlet_count: 2, outlet_count: 1       | [ ]  |
+| 11 | `get_object_hidden`    | 非表示状態を取得               | hidden: false (デフォルト)            | [ ]  |
+| 12 | `set_object_hidden`    | 非表示に設定→元に戻す          | hidden: true → hidden: false          | [ ]  |
+| 13 | `redraw_object`        | オブジェクトを再描画           | success: true                         | [ ]  |
+| 14 | `replace_object_text`  | `cycle~ 440` → `cycle~ 880`    | old_text/new_text が正しく返る        | [ ]  |
+| 15 | `assign_varnames`      | varname なしオブジェクトに付与 | assigned: 1, varname が設定される     | [ ]  |
+
+## Connection Operations (4)
+
+| #  | Tool                      | Test                    | Expected                                  | Pass |
+|----|---------------------------|-------------------------|-------------------------------------------|------|
+| 16 | `connect_max_objects`     | 2つのオブジェクトを接続 | status: success, パッチコードが表示される | [ ]  |
+| 17 | `disconnect_max_objects`  | 接続を切断              | status: success, パッチコードが消える     | [ ]  |
+| 18 | `get_patchlines`          | パッチコード一覧取得    | patchlines 配列に接続情報が含まれる       | [ ]  |
+| 19 | `set_patchline_midpoints` | 中間点を設定→削除       | midpoints 設定/空配列で解除               | [ ]  |
+
+## Patch State (3)
+
+| #  | Tool                   | Test                  | Expected                                    | Pass |
+|----|------------------------|-----------------------|---------------------------------------------|------|
+| 20 | `get_patch_lock_state` | ロック状態を取得      | locked: true/false が返る                   | [ ]  |
+| 21 | `set_patch_lock_state` | ロック→アンロック切替 | パッチの編集/プレゼンテーションが切り替わる | [ ]  |
+| 22 | `get_patch_dirty`      | ダーティ状態を取得    | dirty: true/false が返る                    | [ ]  |
+
+## Hierarchy (2)
+
+| #  | Tool                 | Test                     | Expected                           | Pass |
+|----|----------------------|--------------------------|------------------------------------|------|
+| 23 | `get_parent_patcher` | トップレベルパッチで実行 | エラー: "No parent patcher" (正常) | [ ]  |
+| 24 | `get_subpatchers`    | サブパッチャーなしで実行 | count: 0, subpatchers: []          | [ ]  |
+
+## Utilities (2)
+
+| # | Tool | Test | Expected | Pass |
+|---|------|------|----------|------|
+| 25 | `get_console_log` | コンソールログを取得 | ログメッセージの配列が返る | [ ] |
+| 26 | `get_avoid_rect_position` | 空き位置を取得 | 既存オブジェクトと重ならない座標が返る | [ ] |
+
+---
+
+## Test Flow (推奨手順)
+
+効率的にテストするための推奨手順:
+
+1. **接続確認**: Prerequisites の4項目を確認
+2. **オブジェクト作成**: number, cycle~, gain~, dac~ を作成 (#4)
+3. **オブジェクト操作**: 属性/値/IO/表示を確認 (#6-15)
+4. **接続操作**: オブジェクトを接続→切断 (#16-19)
+5. **パッチ状態**: ロック/ダーティ確認 (#20-22)
+6. **階層**: 親パッチャー/サブパッチャー確認 (#23-24)
+7. **ユーティリティ**: ログ/位置取得 (#25-26)
+8. **クリーンアップ**: テスト用オブジェクトを削除 (#5)
+
+---
+
+## Notes
+
+- `get_parent_patcher` はトップレベルパッチに対してエラーを返すのが正常動作
+- `get_subpatchers` はサブパッチャーがなければ空配列を返すのが正常動作
+- Hierarchy の完全なテストにはサブパッチャー（p, poly~, bpatcher 等）を含むパッチが必要


### PR DESCRIPTION
## Summary

- Add `docs/integration-test-checklist.md` with table-format checklist covering all 26 MCP tools
- Add references in `docs/INDEX.md` and `CLAUDE.md`

## Test plan

- [x] All 26 tools listed and verified against CLAUDE.md tool table
- [x] Links in INDEX.md and CLAUDE.md are correct
- [x] Documentation language consistent with project (English)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)