### PR TITLE
fix(tools): add oneOf type constraint to set_object_attribute value param

### DIFF
--- a/src/tools/object_tools.cpp
+++ b/src/tools/object_tools.cpp
@@ -624,8 +624,15 @@ json get_tool_schemas() {
                     {"attribute", {{"type", "string"}, {"description", "Attribute name to set"}}},
                     {"value", {
                         {"description",
-                            "Attribute value (number, string, or array). "
-                            "e.g. 440, \"hello\", [100, 200, 300, 50]"}
+                            "Attribute value. Pass numbers as JSON numbers, strings as JSON strings, "
+                            "and multi-value attributes (patching_rect, bgcolor, etc.) as JSON arrays "
+                            "of numbers WITHOUT surrounding quotes. "
+                            "e.g. 440, \"hello\", [100, 200, 300, 50]"},
+                        {"oneOf", json::array({
+                            json{{"type", "number"}},
+                            json{{"type", "string"}},
+                            json{{"type", "array"}, {"items", json{{"type", "number"}}}}
+                        })}
                     }}
                 }},
                 {"required", json::array({"patch_id", "varname", "attribute", "value"})}


### PR DESCRIPTION
## Summary

- `set_object_attribute` の `value` パラメータに JSON Schema の型制約が無かったため、一部の MCP クライアント（LLM）が配列値を文字列としてシリアライズしてしまい (`"[100, 200, 300, 50]"`)、Max 側で "bad number" エラーが発生していた
- `oneOf: [number, string, array<number>]` を追加して受理可能な型を明示
- description にも「配列はクォート無しの JSON 配列で渡す」ことを明記

## Reproduction

修正前、Claude が以下のような payload を送信して失敗していた：

```json
{"name":"set_object_attribute","arguments":{"value":"[300, 250, 24, 24]"}}
```

スキーマに型情報が無かったため、LLM が `value` を string にフォールバックしていたのが原因。

## Test plan

- [x] ビルド成功（`./build.sh`）
- [x] `./deploy.sh` で Max 9 Packages へ反映
- [x] [docs/integration-test-checklist.md](docs/integration-test-checklist.md) 全 26 ツール手動検証
  - `set_object_attribute` で `bgcolor [1, 0.5, 0, 1]` → success
  - `set_object_attribute` で `patching_rect [120, 220, 60, 22]` → success
  - `get_object_attribute` で読み戻して値一致確認
- [x] 数値・文字列スカラー値の既存挙動も影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)