### PR TITLE
fix(tools): add JSON Schema type constraints to add_max_object params

### DIFF
--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -110,8 +110,8 @@ Add a Max object to a patch.
   "obj_type": {"type": "string", "required": true, "description": "e.g., 'cycle~', 'number', 'button'"},
   "position": {"type": "array", "required": true, "description": "[x, y] coordinates"},
   "varname": {"type": "string", "required": false, "description": "Variable name for the object"},
-  "arguments": {"type": "array", "required": false, "description": "Object arguments, e.g., [440]"},
-  "attributes": {"type": "object", "required": false, "description": "Object attributes"}
+  "arguments": {"type": "array", "items": {"oneOf": ["number", "string"]}, "required": false, "description": "Object arguments as a JSON array. Each element must be a JSON number or string WITHOUT surrounding quotes around the array. e.g., [440], [\"sine\"]"},
+  "attributes": {"type": "object", "additionalProperties": {"oneOf": ["number", "string", "array<number>"]}, "required": false, "description": "Object attributes as a JSON object. Each value must be a JSON number, string, or array of numbers WITHOUT surrounding quotes. e.g., {\"bgcolor\": [1.0, 0.5, 0.0, 1.0]}"}
 }
 ```
 
@@ -187,7 +187,7 @@ Set an attribute of a Max object.
   "patch_id": {"type": "string", "required": true},
   "varname": {"type": "string", "required": true},
   "attribute": {"type": "string", "required": true},
-  "value": {"required": true, "description": "Number, string, or array"}
+  "value": {"oneOf": ["number", "string", "array<number>"], "required": true, "description": "Attribute value. Pass numbers as JSON numbers, strings as JSON strings, and multi-value attributes (patching_rect, bgcolor, etc.) as JSON arrays of numbers WITHOUT surrounding quotes. e.g., 440, \"hello\", [100, 200, 300, 50]"}
 }
 ```
 

--- a/src/tools/object_tools.cpp
+++ b/src/tools/object_tools.cpp
@@ -573,11 +573,26 @@ json get_tool_schemas() {
                     }},
                     {"arguments", {
                         {"type", "array"},
-                        {"description", "Object arguments (e.g., [440] for 'cycle~')"}
+                        {"items", {{"oneOf", json::array({
+                            json{{"type", "number"}},
+                            json{{"type", "string"}}
+                        })}}},
+                        {"description",
+                            "Object arguments as a JSON array. Each element must be a JSON "
+                            "number or string WITHOUT surrounding quotes around the array. "
+                            "e.g., [440] for 'cycle~', [\"sine\"] for a symbol argument"}
                     }},
                     {"attributes", {
                         {"type", "object"},
-                        {"description", "Object attributes (e.g., {\"bgcolor\": [1.0, 0.5, 0.0, 1.0]})"}
+                        {"additionalProperties", {{"oneOf", json::array({
+                            json{{"type", "number"}},
+                            json{{"type", "string"}},
+                            json{{"type", "array"}, {"items", json{{"type", "number"}}}}
+                        })}}},
+                        {"description",
+                            "Object attributes as a JSON object. Each value must be a JSON "
+                            "number, string, or array of numbers WITHOUT surrounding quotes. "
+                            "e.g., {\"bgcolor\": [1.0, 0.5, 0.0, 1.0]}"}
                     }}
                 }},
                 {"required", json::array({"patch_id", "obj_type", "position"})}


### PR DESCRIPTION
## Summary
- `add_max_object` の `arguments` / `attributes` パラメータに JSON Schema の型制約を追加
- 直前のコミット 1d5d06e (`set_object_attribute` の `value` 修正) と同種のバグへの対処
- LLM クライアントが配列を文字列化 (`"[440]"`) する問題を防止
- `docs/mcp-tools-reference.md` を更新し、本 PR の変更と 1d5d06e で未反映だった `set_object_attribute` の型情報を同期

## Changes
- `arguments`: `items: oneOf [number, string]` を追加
- `attributes`: `additionalProperties: oneOf [number, string, array<number>]` を追加
- description を「JSON 配列/オブジェクトとして渡せ。文字列化禁止」と明確化

## Test plan
- [x] `./build.sh --test` で全 117 テスト通過
- [x] clang-format 適用済み
- [x] code-reviewer agent によるレビュー承認
- [ ] Max 上で `add_max_object` に `arguments=[440]` と `attributes={"bgcolor": [1.0, 0.5, 0.0, 1.0]}` を渡し、LLM が文字列化せず正しく解釈されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)