### PR TITLE
ci: pin Max SDK to v8.2.0 to fix broken builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,12 @@ jobs:
 
       - name: Clone Max SDK
         run: |
-          git clone --depth 1 https://github.com/Cycling74/max-sdk.git max-sdk
+          # Pin to v8.2.0: max-sdk's default branch was restructured to fetch
+          # max-sdk-base via CMake FetchContent and no longer ships the
+          # source/max-sdk-base submodule that this project's CMakeLists expects.
+          git clone --depth 1 --branch v8.2.0 https://github.com/Cycling74/max-sdk.git max-sdk
           cd max-sdk
-          git submodule update --init --recursive --depth 1
+          git submodule update --init --recursive
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -24,9 +24,12 @@ jobs:
 
       - name: Clone Max SDK
         run: |
-          git clone --depth 1 https://github.com/Cycling74/max-sdk.git max-sdk
+          # Pin to v8.2.0: max-sdk's default branch was restructured to fetch
+          # max-sdk-base via CMake FetchContent and no longer ships the
+          # source/max-sdk-base submodule that this project's CMakeLists expects.
+          git clone --depth 1 --branch v8.2.0 https://github.com/Cycling74/max-sdk.git max-sdk
           cd max-sdk
-          git submodule update --init --recursive --depth 1
+          git submodule update --init --recursive
 
       - name: Install dependencies
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ WebSocket Thread → defer() → Max Main Thread → Execute Max API
 ## Dependencies
 
 - **C++17** (required)
-- **Max SDK 8.6+** (clone to `max-sdk/` directory)
+- **Max SDK v8.2.0** (clone to `max-sdk/` directory; newer max-sdk dropped the `max-sdk-base` submodule this project requires)
 - **nlohmann/json 3.11.0+** (`brew install nlohmann-json`)
 - **libwebsockets** (`brew install libwebsockets`)
 - **Google Test** (for tests only, `brew install googletest`)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Max/MSP Patches
 
 ## Tech Stack
 
-- **Language**: C/C++ (Max SDK 8.6+)
+- **Language**: C/C++ (Max SDK v8.2.0)
 - **Build System**: CMake 3.19+
 - **Architecture**: arm64 (Apple Silicon native)
 - **MCP Protocol**: stdio-based JSON-RPC
@@ -75,9 +75,9 @@ Use this path if you're cloning the repository and want to build the external yo
    - Requires macOS 13+, Xcode Command Line Tools, Max 9.1+, Node.js 18+ with npm.
 3. **Fetch the Max SDK with submodules**
    ```bash
-   git clone https://github.com/Cycling74/max-sdk.git --recursive max-sdk
+   git clone --branch v8.2.0 https://github.com/Cycling74/max-sdk.git --recursive max-sdk
    ```
-   The `--recursive` flag is critical; without it `max-pretarget.cmake` is missing.
+   The `--recursive` flag is critical; without it `max-pretarget.cmake` is missing. v8.2.0 is pinned because newer max-sdk no longer ships the `max-sdk-base` submodule (it switched to CMake FetchContent).
 4. **Install bridge dependencies**
    ```bash
    cd package/MaxMCP/support/bridge

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -97,7 +97,7 @@ json validate_and_respond(const json& params) {
 brew install cmake nlohmann-json libwebsockets openssl googletest
 
 # Clone Max SDK (recursive for submodules)
-git clone https://github.com/Cycling74/max-sdk.git --recursive max-sdk
+git clone --branch v8.2.0 https://github.com/Cycling74/max-sdk.git --recursive max-sdk
 ```
 
 ### 2.2 Project Initialization
@@ -106,7 +106,7 @@ git clone https://github.com/Cycling74/max-sdk.git --recursive max-sdk
 # Clone and set up
 git clone https://github.com/signalcompose/MaxMCP.git
 cd MaxMCP
-git clone https://github.com/Cycling74/max-sdk.git --recursive max-sdk
+git clone --branch v8.2.0 https://github.com/Cycling74/max-sdk.git --recursive max-sdk
 
 # Install bridge dependencies
 cd package/MaxMCP/support/bridge && npm install && cd ../../../..

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -877,7 +877,7 @@ TEST(MCPServer, ListToolsReturnsArray) {
 
 | Risk | Probability | Impact | Mitigation |
 |------|-------------|--------|------------|
-| Max SDK version incompatibility | Medium | High | Test with Max SDK 8.6+ early |
+| Max SDK version incompatibility | Medium | High | Test with Max SDK v8.2.0 early |
 | Thread safety issues (defer_low) | High | Critical | Review all Max API calls, add assertions |
 | stdio buffering problems | Low | Medium | Use line-based protocol, flush after writes |
 | CMake configuration errors | Medium | Medium | Use Max SDK example CMakeLists.txt as base |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -62,7 +62,7 @@ Claude Code:
 ## Tech Stack
 
 ### Confirmed Choices
-- **Language**: C/C++17 (Max SDK 8.6+)
+- **Language**: C/C++17 (Max SDK v8.2.0)
 - **Build System**: CMake
 - **MCP Protocol**: stdio ↔ WebSocket (via Node.js bridge)
 - **JSON Library**: nlohmann/json
@@ -157,9 +157,9 @@ Follow this exact order to reproduce the working installation from our latest de
    ```bash
    git clone https://github.com/signalcompose/MaxMCP.git
    cd MaxMCP
-   git clone https://github.com/Cycling74/max-sdk.git --recursive max-sdk
+   git clone --branch v8.2.0 https://github.com/Cycling74/max-sdk.git --recursive max-sdk
    ```
-   > The `--recursive` flag is mandatory; without it the `max-pretarget.cmake` script is missing.
+   > The `--recursive` flag is mandatory; without it the `max-pretarget.cmake` script is missing. v8.2.0 is pinned because newer max-sdk no longer ships the `max-sdk-base` submodule (it switched to CMake FetchContent).
 
 2. **Install system dependencies**
    ```bash

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -260,7 +260,7 @@ Develop a native MCP server external object for Max/MSP, enabling Claude Code to
 - **Rationale**: Cover 95% of Max users
 
 #### NFR-8: Max SDK
-- **Requirement**: Max SDK 8.6+
+- **Requirement**: Max SDK v8.2.0
 - **Rationale**: C++ standard library compatibility
 
 ### 3.3 Reliability
@@ -437,7 +437,7 @@ These may be considered for future versions based on user feedback.
 ## 9. Dependencies
 
 ### 9.1 External Dependencies
-- Max SDK 8.6+
+- Max SDK v8.2.0
 - CMake 3.19+
 - nlohmann/json 3.11.0+
 - libwebsockets

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -20,7 +20,7 @@ Develop a native MCP server external object for Max/MSP, enabling Claude Code to
 4. **Natural language**: "Add oscillator to synth patch" just works
 
 ### Tech Stack
-- **C/C++17** (Max SDK 8.6+)
+- **C/C++17** (Max SDK v8.2.0)
 - **WebSocket** (libwebsockets)
 - **Node.js Bridge** (stdio-to-WebSocket translation)
 - **CMake** (Cross-platform builds)

--- a/package/MaxMCP/README.md
+++ b/package/MaxMCP/README.md
@@ -208,7 +208,7 @@ Each patch gets a unique ID when `[maxmcp]` is created:
 
 **Prerequisites**:
 - CMake 3.19+
-- Max SDK 8.6+
+- Max SDK v8.2.0
 - Xcode (macOS)
 - nlohmann/json
 


### PR DESCRIPTION
## 問題

CI の **C++ Build & Test** が `Max SDK not found` で失敗するようになりました（6/2〜）。本リポジトリのソースは無関係で、5/10 の main では同じ CI 設定で成功していました。

## 原因（確定）

**Cycling74/max-sdk が default ブランチを破壊的に再構成**しました。

| | 旧（〜5月） | 新（現在の main） |
|---|---|---|
| max-sdk-base | `source/max-sdk-base` の git **サブモジュール** | **CMake FetchContent** で取得（ディレクトリ自体が無い） |
| ビルドスクリプト | `script/max-pretarget.cmake` | 新 API（`max::external`） |

本プロジェクトの `CMakeLists.txt` は旧構造（`source/max-sdk-base/script/max-pretarget.cmake`）を前提とするため、CI が毎回フレッシュにクローンする max-sdk が新構造になった結果、`.gitmodules` が無く `git submodule update` が空振りして SDK が欠落します。ローカルで再現・確定済み。

## 修正

- `ci.yml` / `release-assets.yml`: max-sdk クローンを**旧構造の最終タグ `v8.2.0` に固定**し、サブモジュール取得の `--depth 1` を除去（固定タグの base コミットが tip でない場合の shallow fetch 失敗を回避）
- `README` / `quick-start` / `development-guide`: ローカル開発の clone 手順も v8.2.0 固定にし理由を注記
- 実在しないバージョンを指していた「Max SDK 8.6+」記載を、実際にビルド可能な **v8.2.0** に統一（DDD 整合）

## 検証

ローカルで CI と同一手順を再現:
- 現 default ブランチ → `.gitmodules` 無し・`max-pretarget.cmake` 欠落（失敗を再現）
- `--branch v8.2.0` + `git submodule update --init --recursive` → `source/max-sdk-base/script/max-pretarget.cmake` 取得を確認 ✅

## 補足

新 FetchContent ベースの max-sdk-base API への移行は別途追跡（本 PR は CI 復旧が目的の最小変更）。この修正は docs PR #73 の CI ブロッカー解消にもなります（マージ後に #73 をリベース予定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)