### PR TITLE
feat(tools): add near_x/near_y to get_avoid_rect_position (#72)

### DIFF
--- a/docs/integration-test-checklist.md
+++ b/docs/integration-test-checklist.md
@@ -69,10 +69,14 @@
 
 ## Utilities (2)
 
-| #  | Tool                      | Test                    | Expected                                      | Pass |
-|----|---------------------------|-------------------------|-----------------------------------------------|------|
-| 25 | `get_console_log`         | Retrieve console log    | Array of log messages returned                | [ ]  |
-| 26 | `get_avoid_rect_position` | Find empty position     | Returns coordinates avoiding existing objects | [ ]  |
+| #   | Tool                      | Test                                  | Expected                                                              | Pass |
+|-----|---------------------------|---------------------------------------|----------------------------------------------------------------------|------|
+| 25  | `get_console_log`         | Retrieve console log                  | Array of log messages returned                                       | [ ]  |
+| 26  | `get_avoid_rect_position` | No `near_x`/`near_y`                   | Placed to the right of existing objects; rationale mentions "right"  | [ ]  |
+| 26a | `get_avoid_rect_position` | `near_x`/`near_y` at a free spot      | Returns that exact point; rationale mentions "near"                  | [ ]  |
+| 26b | `get_avoid_rect_position` | `near_x`/`near_y` on top of an object | Returns the nearest non-overlapping spot; rationale mentions "nearest" | [ ]  |
+| 26c | `get_avoid_rect_position` | `width`/`height` of a large object    | Returned spot clears all objects by the gap for that size; rationale notes the size | [ ]  |
+| 26d | `get_avoid_rect_position` | Negative `near_x`/`near_y`            | Result clamped to non-negative coordinates (x ≥ 0, y ≥ 0)           | [ ]  |
 
 ---
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -730,14 +730,21 @@ Retrieve recent Max Console messages.
 
 ### `get_avoid_rect_position`
 
-Find an empty position for placing new objects.
+Find an empty (non-overlapping) position for a new object.
+
+- With `near_x`/`near_y`: returns the nearest free spot to that target point,
+  searching outward on a grid until the object clears every existing box.
+- Without them: places the object to the right of all existing objects (the
+  default when no anchor is given).
 
 **Parameters**:
 ```json
 {
   "patch_id": {"type": "string", "required": true},
   "width": {"type": "number", "required": false, "description": "Object width (default: 50)"},
-  "height": {"type": "number", "required": false, "description": "Object height (default: 20)"}
+  "height": {"type": "number", "required": false, "description": "Object height (default: 20)"},
+  "near_x": {"type": "number", "required": false, "description": "Optional target x; provide with near_y to search near a point"},
+  "near_y": {"type": "number", "required": false, "description": "Optional target y; provide with near_x to search near a point"}
 }
 ```
 
@@ -746,7 +753,9 @@ Find an empty position for placing new objects.
 {
   "result": {
     "position": [250, 50],
-    "rationale": "Positioned to the right of existing objects with 50px margin"
+    "width": 50,
+    "height": 20,
+    "rationale": "Placed to the right of existing objects"
   }
 }
 ```

--- a/plugins/maxmcp/skills/patch-guidelines/SKILL.md
+++ b/plugins/maxmcp/skills/patch-guidelines/SKILL.md
@@ -43,12 +43,14 @@ flowchart TD
 Use `get_avoid_rect_position` to find safe positions that don't overlap existing objects:
 
 ```javascript
-// Before adding an object, find a safe position.
-// Current behavior: places to the right of existing objects.
+// Before adding an object, find a safe (non-overlapping) position.
+// With near_x/near_y it returns the nearest free spot to that point;
+// without them it places to the right of existing objects.
 // Returns { position: [x, y], width, height, rationale }.
-// (A near_x/near_y hint is planned — see issue #72.)
 const result = await mcp.get_avoid_rect_position({
   patch_id: "...",
+  near_x: 100,   // optional target point
+  near_y: 200,
   width: 80,
   height: 20
 });

--- a/plugins/maxmcp/skills/patch-guidelines/reference/layout-rules.md
+++ b/plugins/maxmcp/skills/patch-guidelines/reference/layout-rules.md
@@ -496,11 +496,14 @@ Always use this tool to find safe positions:
 
 ```javascript
 // Find a free position for a new object of the given size.
-// The tool places it to the right of existing objects (current behavior).
+// near_x/near_y (optional): search for the nearest non-overlapping spot to
+// that target point. Omit them to place to the right of existing objects.
 const pos = await mcp.get_avoid_rect_position({
   patch_id: "patch_123",
-  width: 80,   // estimated object width
-  height: 20   // estimated object height
+  near_x: 100,  // optional: desired location
+  near_y: 200,
+  width: 80,    // estimated object width
+  height: 20    // estimated object height
 });
 
 // Returns { position: [x, y], width, height, rationale }
@@ -511,9 +514,6 @@ await mcp.add_max_object({
   // ...
 });
 ```
-
-> Note: a `near_x` / `near_y` hint (place near a target point with true
-> non-overlap search) is planned but not yet implemented — see issue #72.
 
 ## Multi-Column Layouts
 

--- a/src/tools/utility_tools.cpp
+++ b/src/tools/utility_tools.cpp
@@ -13,6 +13,9 @@
 
 #include "tool_common.h"
 
+#include <algorithm>
+#include <cmath>
+
 #ifndef MAXMCP_TEST_MODE
 #include "ext.h"
 
@@ -28,6 +31,120 @@ namespace UtilityTools {
 using ToolCommon::DeferredResult;
 
 // ============================================================================
+// Geometry: nearest non-overlapping placement (Max-API independent, testable)
+// ============================================================================
+
+// Two rectangles conflict if they are closer than `gap` on both axes.
+// Public so the same predicate can be reused by unit tests.
+bool rects_conflict(const Rect& a, const Rect& b, double gap) {
+    return a.x < b.x + b.width + gap && b.x < a.x + a.width + gap && a.y < b.y + b.height + gap &&
+           b.y < a.y + a.height + gap;
+}
+
+namespace {
+
+constexpr double PLACE_MARGIN = 50.0;        // gap used when stacking to the right
+constexpr double PLACE_GAP = 8.0;            // minimum visual gap between objects
+constexpr double PLACE_GRID = 15.0;          // search step (matches Max default grid)
+constexpr double PLACE_MAX_RADIUS = 4000.0;  // give up beyond this many px
+
+struct Point {
+    double x;
+    double y;
+};
+
+// A width x height rect at (x, y) is valid when it stays in the visible area
+// and clears every existing rect (keeping PLACE_GAP of separation).
+bool position_is_free(double x, double y, double width, double height,
+                      const std::vector<Rect>& existing) {
+    if (x < 0.0 || y < 0.0) {
+        return false;
+    }
+    const Rect candidate{x, y, width, height};
+    for (const Rect& r : existing) {
+        if (rects_conflict(candidate, r, PLACE_GAP)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+double rightmost_edge(const std::vector<Rect>& existing) {
+    double edge = 0.0;
+    for (const Rect& r : existing) {
+        edge = std::max(edge, r.x + r.width);
+    }
+    return edge;
+}
+
+std::string coord_pair(double x, double y) {
+    return "(" + std::to_string(static_cast<int>(x)) + ", " + std::to_string(static_cast<int>(y)) +
+           ")";
+}
+
+// Where to start searching from, plus a human-readable description.
+Point search_anchor(const std::vector<Rect>& existing, bool has_near, double near_x, double near_y,
+                    std::string& desc) {
+    if (has_near) {
+        desc = "near " + coord_pair(near_x, near_y);
+        return {std::max(0.0, near_x), std::max(0.0, near_y)};
+    }
+    if (existing.empty()) {
+        desc = "default origin (empty patch)";
+        return {50.0, 50.0};
+    }
+    desc = "to the right of existing objects";
+    return {rightmost_edge(existing) + PLACE_MARGIN, 50.0};
+}
+
+// Nearest (Euclidean) free spot on the square ring at Chebyshev distance
+// `radius` from the anchor. Returns false if the ring has no free spot.
+bool nearest_free_on_ring(const Point& anchor, double radius, double width, double height,
+                          const std::vector<Rect>& existing, Point& out) {
+    bool found = false;
+    double best_dist2 = 0.0;
+    for (double dx = -radius; dx <= radius; dx += PLACE_GRID) {
+        for (double dy = -radius; dy <= radius; dy += PLACE_GRID) {
+            const bool on_perimeter = std::max(std::fabs(dx), std::fabs(dy)) >= radius;
+            if (!on_perimeter ||
+                !position_is_free(anchor.x + dx, anchor.y + dy, width, height, existing)) {
+                continue;
+            }
+            const double dist2 = dx * dx + dy * dy;
+            if (!found || dist2 < best_dist2) {
+                found = true;
+                best_dist2 = dist2;
+                out = {anchor.x + dx, anchor.y + dy};
+            }
+        }
+    }
+    return found;
+}
+
+}  // namespace
+
+PlacedPosition find_avoid_rect_position(const std::vector<Rect>& existing, double width,
+                                        double height, bool has_near, double near_x,
+                                        double near_y) {
+    std::string desc;
+    const Point anchor = search_anchor(existing, has_near, near_x, near_y, desc);
+
+    if (position_is_free(anchor.x, anchor.y, width, height, existing)) {
+        return {anchor.x, anchor.y, "Placed " + desc};
+    }
+
+    Point spot{};
+    for (double radius = PLACE_GRID; radius <= PLACE_MAX_RADIUS; radius += PLACE_GRID) {
+        if (nearest_free_on_ring(anchor, radius, width, height, existing, spot)) {
+            return {spot.x, spot.y, "Found nearest free position " + desc};
+        }
+    }
+
+    // Fallback for an extremely dense patch: the far right is always free.
+    return {rightmost_edge(existing) + PLACE_MARGIN, 50.0, "Fallback: placed to the far right"};
+}
+
+// ============================================================================
 // Data Structures for Deferred Callbacks
 // ============================================================================
 
@@ -35,6 +152,9 @@ struct t_get_position_data {
     t_maxmcp* patch;
     double width;
     double height;
+    bool has_near;
+    double near_x;
+    double near_y;
     DeferredResult* deferred_result;
 };
 
@@ -45,46 +165,36 @@ struct t_get_position_data {
 #ifndef MAXMCP_TEST_MODE
 
 /**
- * @brief Deferred callback for finding empty position
+ * @brief Deferred callback for finding an empty position
  *
- * Executed on main thread via defer(). Scans existing objects and finds
- * position to the right of all existing objects with margin, considering
- * the requested object dimensions.
+ * Executed on main thread via defer(). Collects the patching rectangles of all
+ * existing objects, then delegates the placement decision to the Max-API
+ * independent find_avoid_rect_position() so the geometry stays unit-testable.
  */
 static void get_position_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_atom* argv) {
     VALIDATE_DEFERRED_ARGS("get_position_deferred");
     EXTRACT_DEFERRED_DATA_WITH_RESULT(t_get_position_data, data, argv);
 
     t_object* patcher = data->patch->patcher;
-    double max_x = 50.0;  // Default starting position
-    double start_y = 50.0;
-    double margin = 50.0;
 
-    // Find bounding box of existing objects
+    // Collect the patching rectangle of every existing object.
+    std::vector<Rect> existing;
     for (t_object* box = jpatcher_get_firstobject(patcher); box; box = jbox_get_nextobject(box)) {
         t_rect rect;
         jbox_get_patching_rect(box, &rect);
-
-        // Update max_x to be past the rightmost object
-        double box_right = rect.x + rect.width;
-        if (box_right > max_x) {
-            max_x = box_right;
-        }
+        existing.push_back({rect.x, rect.y, rect.width, rect.height});
     }
 
-    // Calculate position with margin, ensuring the new object fits
-    double new_x = max_x + margin;
-    double new_y = start_y;
+    PlacedPosition placed = find_avoid_rect_position(existing, data->width, data->height,
+                                                     data->has_near, data->near_x, data->near_y);
 
-    // Build rationale including dimensions if non-default
-    std::string rationale = "Positioned to the right of existing objects with " +
-                            std::to_string(static_cast<int>(margin)) + "px margin";
+    std::string rationale = placed.rationale;
     if (data->width != 50.0 || data->height != 20.0) {
         rationale += " (for object " + std::to_string(static_cast<int>(data->width)) + "x" +
                      std::to_string(static_cast<int>(data->height)) + ")";
     }
 
-    COMPLETE_DEFERRED(data, json({{"position", json::array({new_x, new_y})},
+    COMPLETE_DEFERRED(data, json({{"position", json::array({placed.x, placed.y})},
                                   {"width", data->width},
                                   {"height", data->height},
                                   {"rationale", rationale}}));
@@ -113,13 +223,22 @@ json get_tool_schemas() {
 
          // get_avoid_rect_position
          {{"name", "get_avoid_rect_position"},
-          {"description", "Find an empty position for placing new objects"},
+          {"description", "Find an empty (non-overlapping) position for a new object. With "
+                          "near_x/near_y, returns the nearest free spot to that point; "
+                          "otherwise places to the right of existing objects."},
           {"inputSchema",
            {{"type", "object"},
             {"properties",
              {{"patch_id", {{"type", "string"}, {"description", "Patch ID to query"}}},
               {"width", {{"type", "number"}, {"description", "Object width (default: 50)"}}},
-              {"height", {{"type", "number"}, {"description", "Object height (default: 20)"}}}}},
+              {"height", {{"type", "number"}, {"description", "Object height (default: 20)"}}},
+              {"near_x",
+               {{"type", "number"},
+                {"description", "Optional target x. Provide with near_y to search near a point."}}},
+              {"near_y",
+               {{"type", "number"},
+                {"description",
+                 "Optional target y. Provide with near_x to search near a point."}}}}},
             {"required", json::array({"patch_id"})}}}}});
 }
 
@@ -153,13 +272,20 @@ static json execute_get_avoid_rect_position(const json& params) {
         return ToolCommon::missing_param_error("patch_id");
     }
 
+    // near_x/near_y are optional: when both are present, the search anchors at
+    // that point; otherwise it falls back to placing to the right.
+    bool has_near = params.contains("near_x") && params.contains("near_y");
+    double near_x = params.value("near_x", 0.0);
+    double near_y = params.value("near_y", 0.0);
+
     t_maxmcp* patch = PatchRegistry::find_patch(patch_id);
     if (!patch) {
         return ToolCommon::patch_not_found_error(patch_id);
     }
 
     auto* deferred_result = new DeferredResult();
-    auto* data = new t_get_position_data{patch, width, height, deferred_result};
+    auto* data =
+        new t_get_position_data{patch, width, height, has_near, near_x, near_y, deferred_result};
 
     t_atom a;
     atom_setobj(&a, data);

--- a/src/tools/utility_tools.h
+++ b/src/tools/utility_tools.h
@@ -13,6 +13,7 @@
 #define UTILITY_TOOLS_H
 
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -23,6 +24,67 @@ typedef struct _maxmcp t_maxmcp;
 namespace UtilityTools {
 
 using json = nlohmann::json;
+
+// ============================================================================
+// Geometry helpers for get_avoid_rect_position (Max-API independent, testable)
+// ============================================================================
+
+/**
+ * @brief Axis-aligned rectangle in patch coordinates.
+ */
+struct Rect {
+    double x;
+    double y;
+    double width;
+    double height;
+};
+
+/**
+ * @brief Result of a placement search.
+ */
+struct PlacedPosition {
+    double x;
+    double y;
+    std::string rationale;
+};
+
+/**
+ * @brief Whether two rectangles are closer than @p gap on both axes.
+ *
+ * With @p gap == 0 this is a plain (strict) axis-aligned overlap test: rectangles
+ * that merely touch edges do not conflict. A positive @p gap additionally
+ * enforces that much clearance — rectangles separated by exactly @p gap do not
+ * conflict, while anything closer does.
+ *
+ * @param a   First rectangle
+ * @param b   Second rectangle
+ * @param gap Required clearance (0 for a pure overlap test)
+ * @return true if the rectangles overlap or sit within @p gap on both axes
+ */
+bool rects_conflict(const Rect& a, const Rect& b, double gap);
+
+/**
+ * @brief Find a non-overlapping position for a new object of the given size.
+ *
+ * Pure geometry, free of any Max API dependency so it can be unit-tested.
+ *
+ * - When @p has_near is true, searches outward from (@p near_x, @p near_y) on a
+ *   grid for the nearest spot where a @p width x @p height rectangle does not
+ *   overlap (within a small gap) any rectangle in @p existing.
+ * - When @p has_near is false, the anchor defaults to the right of all existing
+ *   objects (legacy behavior) — or the origin when the patch is empty — and the
+ *   same non-overlap search is applied from there.
+ *
+ * @param existing Existing object rectangles to avoid
+ * @param width    Width of the rectangle to place
+ * @param height   Height of the rectangle to place
+ * @param has_near Whether a target anchor point was supplied
+ * @param near_x   Target anchor x (used only when @p has_near)
+ * @param near_y   Target anchor y (used only when @p has_near)
+ * @return The chosen position and a human-readable rationale
+ */
+PlacedPosition find_avoid_rect_position(const std::vector<Rect>& existing, double width,
+                                        double height, bool has_near, double near_x, double near_y);
 
 /**
  * @brief Get the JSON schemas for all utility tools

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ set(TOOL_SOURCES
 
 add_executable(test_tool_routing
     unit/test_tool_routing.cpp
+    unit/test_avoid_rect_position.cpp
     ${TOOL_SOURCES}
     ../src/utils/console_logger.cpp
     ../src/utils/patch_registry.cpp

--- a/tests/unit/test_avoid_rect_position.cpp
+++ b/tests/unit/test_avoid_rect_position.cpp
@@ -1,0 +1,180 @@
+/**
+    @file test_avoid_rect_position.cpp
+    Unit tests for UtilityTools::find_avoid_rect_position (pure geometry).
+
+    These tests exercise the Max-API independent placement logic behind the
+    get_avoid_rect_position MCP tool: the non-overlap (gap) guarantee, the
+    near-point search, nearest-spot selection, size sensitivity, bounds, the
+    rationale strings, and the legacy "place to the right" fallback.
+*/
+
+#include "tools/utility_tools.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using UtilityTools::find_avoid_rect_position;
+using UtilityTools::PlacedPosition;
+using UtilityTools::Rect;
+using UtilityTools::rects_conflict;
+
+namespace {
+
+// Mirrors PLACE_GAP in utility_tools.cpp: the minimum clearance the algorithm
+// must keep between the placed object and every existing object.
+constexpr double kGap = 8.0;
+
+// Assert the placed rect clears every existing object by at least kGap, reusing
+// the production predicate (see the RectsConflict tests below for its own
+// boundary coverage).
+void expect_cleared(const PlacedPosition& placed, double width, double height,
+                    const std::vector<Rect>& existing) {
+    const Rect r{placed.x, placed.y, width, height};
+    for (const Rect& e : existing) {
+        EXPECT_FALSE(rects_conflict(r, e, kGap))
+            << "placed (" << placed.x << "," << placed.y << ") is within the gap of existing ("
+            << e.x << "," << e.y << "," << e.width << "," << e.height << ")";
+    }
+}
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// rects_conflict: the overlap/clearance predicate shared with the placement
+// search. Tested directly because expect_cleared() relies on it.
+// ---------------------------------------------------------------------------
+
+// gap == 0 is a plain strict AABB overlap test.
+TEST(RectsConflict, OverlappingRectsConflictWithoutGap) {
+    Rect a{0.0, 0.0, 50.0, 50.0};
+    Rect b{25.0, 25.0, 50.0, 50.0};  // overlaps a
+    EXPECT_TRUE(rects_conflict(a, b, 0.0));
+    EXPECT_TRUE(rects_conflict(b, a, 0.0));  // symmetric
+}
+
+TEST(RectsConflict, EdgeTouchingDoesNotConflictWithoutGap) {
+    Rect a{0.0, 0.0, 50.0, 20.0};
+    Rect b{50.0, 0.0, 50.0, 20.0};  // shares the x=50 edge, no overlap
+    EXPECT_FALSE(rects_conflict(a, b, 0.0));
+}
+
+TEST(RectsConflict, OneAxisSeparatedDoesNotConflict) {
+    Rect a{0.0, 0.0, 50.0, 20.0};
+    Rect b{0.0, 100.0, 50.0, 20.0};  // same x span, far apart in y
+    EXPECT_FALSE(rects_conflict(a, b, 0.0));
+}
+
+TEST(RectsConflict, GapBoundaryIsExclusive) {
+    Rect a{0.0, 0.0, 10.0, 10.0};
+    // b sits exactly `gap` to the right of a (a right edge = 10, gap = 8).
+    Rect at_gap{18.0, 0.0, 10.0, 10.0};
+    EXPECT_FALSE(rects_conflict(a, at_gap, 8.0)) << "exactly gap apart should clear";
+
+    // One pixel closer than the gap -> conflict.
+    Rect within_gap{17.0, 0.0, 10.0, 10.0};
+    EXPECT_TRUE(rects_conflict(a, within_gap, 8.0));
+}
+
+TEST(RectsConflict, WithinGapOnlyConflictsWhenBothAxesClose) {
+    Rect a{0.0, 0.0, 10.0, 10.0};
+    // Within the gap horizontally but clearly separated vertically.
+    Rect b{15.0, 200.0, 10.0, 10.0};
+    EXPECT_FALSE(rects_conflict(a, b, 8.0));
+}
+
+// Empty patch, no anchor -> default origin (50, 50).
+TEST(AvoidRectPosition, EmptyPatchReturnsOrigin) {
+    PlacedPosition p = find_avoid_rect_position({}, 50.0, 20.0, false, 0.0, 0.0);
+    EXPECT_DOUBLE_EQ(p.x, 50.0);
+    EXPECT_DOUBLE_EQ(p.y, 50.0);
+    EXPECT_TRUE(contains(p.rationale, "origin")) << p.rationale;
+}
+
+// No anchor with existing objects -> placed to the right of the rightmost edge
+// (legacy behavior preserved).
+TEST(AvoidRectPosition, NoAnchorPlacesToTheRight) {
+    std::vector<Rect> existing{{50.0, 50.0, 100.0, 22.0}};
+    PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, false, 0.0, 0.0);
+    // rightmost edge = 150, + margin 50 = 200
+    EXPECT_DOUBLE_EQ(p.x, 200.0);
+    EXPECT_DOUBLE_EQ(p.y, 50.0);
+    EXPECT_TRUE(contains(p.rationale, "right")) << p.rationale;
+    expect_cleared(p, 50.0, 20.0, existing);
+}
+
+// A free anchor point is returned exactly, and the rationale names it.
+TEST(AvoidRectPosition, FreeAnchorReturnedExactly) {
+    std::vector<Rect> existing{{0.0, 0.0, 40.0, 40.0}};
+    PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, true, 400.0, 300.0);
+    EXPECT_DOUBLE_EQ(p.x, 400.0);
+    EXPECT_DOUBLE_EQ(p.y, 300.0);
+    EXPECT_TRUE(contains(p.rationale, "near")) << p.rationale;
+    expect_cleared(p, 50.0, 20.0, existing);
+}
+
+// An anchor on top of an object resolves to the *nearest* free spot. For a
+// single 100x40 object at (100,100) and a 50x20 object anchored at the object's
+// center (150,120), the closest grid-aligned, gap-clearing spot is directly
+// below at (150,150): the rows above/left/right all stay within the gap, so the
+// search settles on the first free ring (radius 30) just under the object.
+TEST(AvoidRectPosition, OccupiedAnchorPicksNearestFreeSpot) {
+    std::vector<Rect> existing{{100.0, 100.0, 100.0, 40.0}};
+    PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 120.0);
+    EXPECT_DOUBLE_EQ(p.x, 150.0);
+    EXPECT_DOUBLE_EQ(p.y, 150.0);
+    EXPECT_TRUE(contains(p.rationale, "nearest")) << p.rationale;
+    expect_cleared(p, 50.0, 20.0, existing);
+}
+
+// A small object fits a narrow vertical gap between two stacked objects; a tall
+// object does not and must be relocated elsewhere. Both must stay cleared.
+TEST(AvoidRectPosition, RespectsObjectSizeWhenFittingGaps) {
+    std::vector<Rect> existing{{100.0, 100.0, 100.0, 40.0}, {100.0, 200.0, 100.0, 40.0}};
+    // The gap spans y in [140, 200]; anchor at its middle.
+    PlacedPosition small = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 170.0);
+    EXPECT_DOUBLE_EQ(small.x, 150.0);
+    EXPECT_DOUBLE_EQ(small.y, 170.0);  // 20px-tall object fits, anchor is already free
+    expect_cleared(small, 50.0, 20.0, existing);
+
+    PlacedPosition tall = find_avoid_rect_position(existing, 50.0, 80.0, true, 150.0, 170.0);
+    // 80px tall cannot fit the 60px gap, so it is placed clear of both objects.
+    EXPECT_FALSE(tall.y >= 140.0 && tall.y + 80.0 <= 200.0) << "tall object squeezed into the gap";
+    expect_cleared(tall, 50.0, 80.0, existing);
+}
+
+// Densely packed neighbors: the result must still clear every object.
+TEST(AvoidRectPosition, ClearsAllInClusteredLayout) {
+    std::vector<Rect> existing;
+    for (int row = 0; row < 4; ++row) {
+        for (int col = 0; col < 4; ++col) {
+            existing.push_back({100.0 + col * 60.0, 100.0 + row * 40.0, 50.0, 20.0});
+        }
+    }
+    PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, true, 180.0, 160.0);
+    expect_cleared(p, 50.0, 20.0, existing);
+}
+
+// Negative anchors are clamped; results stay in the visible (non-negative) area.
+TEST(AvoidRectPosition, AvoidsNegativeCoordinates) {
+    std::vector<Rect> existing{{0.0, 0.0, 200.0, 200.0}};
+    PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, true, -100.0, -100.0);
+    EXPECT_GE(p.x, 0.0);
+    EXPECT_GE(p.y, 0.0);
+    expect_cleared(p, 50.0, 20.0, existing);
+}
+
+// Determinism: identical inputs yield identical placements.
+TEST(AvoidRectPosition, IsDeterministic) {
+    std::vector<Rect> existing{{100.0, 100.0, 100.0, 40.0}};
+    PlacedPosition a = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 120.0);
+    PlacedPosition b = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 120.0);
+    EXPECT_DOUBLE_EQ(a.x, b.x);
+    EXPECT_DOUBLE_EQ(a.y, b.y);
+}

--- a/tests/unit/test_tool_routing.cpp
+++ b/tests/unit/test_tool_routing.cpp
@@ -143,8 +143,7 @@ TEST_F(ToolSchemaTest, ExpectedToolNamesPresent) {
         "set_patch_lock_state", "get_patch_dirty",         "get_parent_patcher",
         "get_subpatchers",      "get_console_log",         "get_avoid_rect_position",
         "get_patchlines",       "set_patchline_midpoints", "replace_object_text",
-        "assign_varnames",
-        "get_object_value"};
+        "assign_varnames",      "get_object_value"};
 
     for (const auto& name : expected) {
         EXPECT_TRUE(names.count(name)) << "Missing expected tool: " << name;


### PR DESCRIPTION
## 概要

`get_avoid_rect_position` MCP ツールに、基準点 `near_x`/`near_y`（オプション）と**真の2次元非重複配置探索**を追加しました。スキルドキュメントが以前から記載していた `near_x`/`near_y` の挙動を、実装側で正式にサポートします。

Closes #72

## 変更内容

### 実装 (`src/tools/utility_tools.{cpp,h}`)
- 幾何ロジックを Max API 非依存の純粋関数 `find_avoid_rect_position` に抽出し、`MAXMCP_TEST_MODE` ガード外でユニットテスト可能に
- `rects_conflict`（2矩形が gap 内かを判定する述語）を公開 API 化し、配置探索とユニットテストで共有（DRY）
- 探索を名前付きヘルパー（`search_anchor` / `nearest_free_on_ring` / `position_is_free` / `rightmost_edge`）に分割し、制御フローをフラットに
- `near_x`/`near_y` 指定時はその点（非負へクランプ）をアンカーにリング探索し最寄りの空きスポットを返却。未指定時は従来どおり既存オブジェクトの右へ配置
- schema に `near_x`/`near_y` を追加

### テスト (`tests/unit/test_avoid_rect_position.cpp`、新規)
- `rects_conflict` 境界テスト 5 件（重なり/辺接触/片軸分離/gap 境界の排他性/両軸近接）
- `find_avoid_rect_position` テスト 8 件（空パッチ原点/右配置/空きアンカー正確返却/占有アンカー最寄り探索/サイズ考慮/密集レイアウト/負座標クランプ/決定性）

### ドキュメント
- `docs/mcp-tools-reference.md`: `near_x`/`near_y` パラメータと新レスポンス例
- `docs/integration-test-checklist.md`: 項目 #26a〜#26d を追加
- `plugins/maxmcp/skills/patch-guidelines/{SKILL.md,reference/layout-rules.md}`: `near_x`/`near_y` の使用例を復帰

## 検証

- **ユニットテスト**: 130/130 合格（新規 13 件含む）
- **実機動作確認**: 統合テストチェックリスト全 26 ツール（#26a〜#26d 含む）を実機で合格
  - near なし → 右配置 `(347,50)`
  - near 空きスポット → そのまま返却 `(500,500)`
  - near 占有 → 最寄りの非重複スポット `(150,441)`
  - サイズ考慮（200×100）→ 全オブジェクトをクリア
  - 負座標 → 非負へクランプ `(60,0)`
- **コードレビュー**: pr-review-toolkit code-reviewer により実施、critical/important 問題ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)