### PR TITLE
refactor(tools): consolidate varname/maxclass getters into PatchHelpers

### DIFF
--- a/src/tools/connection_tools.cpp
+++ b/src/tools/connection_tools.cpp
@@ -249,11 +249,6 @@ static void get_patchlines_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_a
     json patchlines = json::array();
     t_object* patcher = data->patch->patcher;
 
-    auto get_varname = [](t_object* box) -> std::string {
-        t_symbol* v = object_attr_getsym(box, gensym("varname"));
-        return (v && v->s_name) ? v->s_name : "";
-    };
-
     // Helpers populating field groups. Each mode picks the helpers it needs.
     auto add_geometry_fields = [](json& pl, t_object* line) {
         double sx, sy, ex, ey;
@@ -306,9 +301,9 @@ static void get_patchlines_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_a
         long inlet = jpatchline_get_inletnum(line);
 
         // Topology fields are included in every mode.
-        json pl = {{"src_varname", get_varname(box1)},
+        json pl = {{"src_varname", PatchHelpers::get_box_varname(box1)},
                    {"outlet", outlet},
-                   {"dst_varname", get_varname(box2)},
+                   {"dst_varname", PatchHelpers::get_box_varname(box2)},
                    {"inlet", inlet}};
 
         switch (data->mode) {

--- a/src/tools/hierarchy_tools.cpp
+++ b/src/tools/hierarchy_tools.cpp
@@ -17,6 +17,7 @@
 
 #include "maxmcp.h"
 #include "utils/console_logger.h"
+#include "utils/patch_helpers.h"
 #include "utils/patch_registry.h"
 
 namespace HierarchyTools {
@@ -76,19 +77,16 @@ static void get_subpatchers_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_
     // Iterate through all boxes to find subpatchers (patcher, bpatcher, poly~)
     for (t_object* box = jpatcher_get_firstobject(data->patch->patcher); box != nullptr;
          box = jbox_get_nextobject(box)) {
-        t_symbol* maxclass = jbox_get_maxclass(box);
-        if (!maxclass || !maxclass->s_name) {
+        std::string class_name = PatchHelpers::get_box_maxclass(box);
+        if (class_name.empty()) {
             continue;
         }
-
-        std::string class_name = maxclass->s_name;
 
         // Check if this is a subpatcher type
         // Max may report "jpatcher" (jbox variant) instead of "patcher"
         if (class_name == "patcher" || class_name == "jpatcher" || class_name == "bpatcher" ||
             class_name == "poly~") {
-            t_symbol* varname = object_attr_getsym(box, gensym("varname"));
-            std::string varname_str = (varname && varname->s_name) ? varname->s_name : "";
+            std::string varname_str = PatchHelpers::get_box_varname(box);
 
             // Get subpatcher name if available
             std::string name_str = "";

--- a/src/tools/object_tools.cpp
+++ b/src/tools/object_tools.cpp
@@ -294,8 +294,7 @@ static void get_objects_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_atom
     // Helpers populating field groups. Each mode picks the helpers it needs.
     auto add_identity_fields = [](json& obj, t_object* box, int index) {
         obj["index"] = index;
-        t_symbol* maxclass = jbox_get_maxclass(box);
-        obj["maxclass"] = (maxclass && maxclass->s_name) ? maxclass->s_name : "unknown";
+        obj["maxclass"] = PatchHelpers::get_box_maxclass(box, "unknown");
         obj["text"] = PatchHelpers::get_box_text(box);
     };
     auto add_geometry_fields = [](json& obj, t_object* box) {
@@ -310,8 +309,7 @@ static void get_objects_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_atom
     int index = 0;
 
     for (t_object* box = jpatcher_get_firstobject(patcher); box; box = jbox_get_nextobject(box)) {
-        t_symbol* varname = object_attr_getsym(box, gensym("varname"));
-        std::string varname_str = (varname && varname->s_name) ? varname->s_name : "";
+        std::string varname_str = PatchHelpers::get_box_varname(box);
 
         json obj_info = json::object();
         if (!varname_str.empty()) {
@@ -434,8 +432,7 @@ static void replace_object_text_deferred(t_maxmcp* patch, t_symbol* s, long argc
     }
 
     // --- 1. Save current box state ---
-    t_symbol* maxclass = jbox_get_maxclass(box);
-    std::string maxclass_str = (maxclass && maxclass->s_name) ? maxclass->s_name : "";
+    std::string maxclass_str = PatchHelpers::get_box_maxclass(box);
     std::string old_text = PatchHelpers::get_box_text(box);
     auto saved_attrs = PatchHelpers::save_box_attributes(box);
     auto saved_connections = PatchHelpers::save_box_connections(patcher, box);
@@ -524,8 +521,7 @@ static void assign_varnames_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_
 
         object_attr_setsym(box, gensym("varname"), gensym(varname.c_str()));
 
-        t_symbol* maxclass = jbox_get_maxclass(box);
-        std::string maxclass_str = (maxclass && maxclass->s_name) ? maxclass->s_name : "unknown";
+        std::string maxclass_str = PatchHelpers::get_box_maxclass(box, "unknown");
 
         assigned.push_back({{"index", idx}, {"varname", varname}, {"maxclass", maxclass_str}});
     }


### PR DESCRIPTION
## 概要

issue #78: box の varname/maxclass を取得する重複パターンを、#76 で新設した共有ヘルパ `PatchHelpers::get_box_varname(t_object*)` / `PatchHelpers::get_box_maxclass(t_object*)` へ統一するリファクタリングです。

挙動不変（デフォルト値・戻り値が既存呼び出し箇所と等価）です。

## 変更内容

- **connection_tools.cpp**: `get_varname` ラムダを削除し `get_box_varname` を使用
- **hierarchy_tools.cpp**: `get_box_maxclass`（空スキップ）と `get_box_varname` を使用、`utils/patch_helpers.h` include 追加
- **object_tools.cpp**: `get_box_varname` / `get_box_maxclass` を使用、各呼び出しのフォールバック（`"unknown"` / `""`）を維持

差分: 3 ファイル、+10 / −21 行

## 検証

### 自動テスト
- `./build.sh --test` 全テスト緑

### 実機統合テスト（全 27 MCP ツール）
[docs/integration-test-checklist.md](docs/integration-test-checklist.md) の全項目を実機で検証し **全 27 ツール PASS**。特に本リファクタが影響する varname/maxclass 返却系を重点確認:
- `get_objects_in_patch`（full/layout/identity 各モード）
- `get_patchlines`（connections モード）
- `get_parent_patcher`（子→親成功・トップレベル→エラー両ケース）
- `get_subpatchers`（サブなし/サブ有り）

→ 挙動不変を実機で確認。

### コードレビュー
`pr-review-toolkit:code-reviewer` による全 7 置換箇所の挙動等価性検証で critical/important/minor すべてゼロ。

## スコープ外（確認済み・対象外）

- `patch_helpers.cpp` の `atom_to_json` 内の sym チェック（atom→string 変換で varname 取得とは別物）
- `find_box_by_varname` 内の varname 比較（用途が異なる）
- `object_attr_setsym` を使う setter 3 箇所（object_tools.cpp:170, 463, 522）

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
