### PR TITLE
chore(bridge): omit dev deps on deploy and bump ws to ^8.21.0

### DIFF
--- a/package/MaxMCP/support/bridge/npm-install.js
+++ b/package/MaxMCP/support/bridge/npm-install.js
@@ -16,7 +16,11 @@ maxApi.post('npm-install.js loaded');
 maxApi.addHandler(maxApi.MESSAGE_TYPES.BANG, () => {
   maxApi.post(`Installing dependencies in: ${bridgeDir}`);
 
-  const npmProcess = spawn('npm', ['install'], {
+  // Install production dependencies only (runtime needs `ws`; eslint/jest/
+  // prettier are devDependencies used for linting/testing and are unnecessary
+  // in the end-user deploy environment). This also suppresses the deprecation
+  // and dev-only audit warnings that the full install surfaces.
+  const npmProcess = spawn('npm', ['install', '--omit=dev'], {
     cwd: bridgeDir,
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/package/MaxMCP/support/bridge/package-lock.json
+++ b/package/MaxMCP/support/bridge/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "name": "maxmcp-bridge",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "ws": "^8.14.0"
+        "ws": "^8.21.0"
       },
       "bin": {
         "maxmcp-bridge": "websocket-mcp-bridge.js"
@@ -5640,9 +5640,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package/MaxMCP/support/bridge/package.json
+++ b/package/MaxMCP/support/bridge/package.json
@@ -24,7 +24,7 @@
     "coverageDirectory": "coverage"
   },
   "dependencies": {
-    "ws": "^8.14.0"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "eslint": "^8.57.0",


### PR DESCRIPTION
## 概要

Issue #81: Max パッケージのデプロイ時（`support/bridge/npm-install.js` 実行時）に出る npm の deprecation 警告と脆弱性監査警告を解消します。今回のスコープは方針 **1+2 のみ**（ESLint 8→9 移行（方針 3）は別軸のため対象外）。

## 原因

`npm-install.js` が `npm install`（devDependencies 込み）を実行していたため、ランタイム不要な eslint/jest/prettier が入り、deprecation 警告（inflight / glob@7 / rimraf@3 / eslint@8 系）と dev 専用脆弱性が表面化していた。本番のランタイム脆弱性は `ws`（GHSA-58qx-3vcg-4xpx）の 1 件のみ。

## 変更内容

- **npm-install.js**: `npm install` → `npm install --omit=dev`。ランタイム依存 `ws` のみインストールし、deprecation 警告と dev 専用 audit 警告を抑止
- **package.json**: `ws` を `^8.14.0` → `^8.21.0` に bump（唯一のランタイム脆弱性 GHSA-58qx-3vcg-4xpx を解消、resolved 8.21.0）
- **package-lock.json**: ws を 8.21.0 に更新。あわせて root `license` フィールドの drift（`"MIT"` → `"SEE LICENSE IN LICENSE"`、package.json と不一致だったもの）を同期

差分: 3 ファイル、+11 / −7 行

## 検証

### 静的チェック
- `npm audit --omit=dev` → **0 vulnerabilities**
- `npm run lint`（eslint）→ クリーン
- `npm test`（jest）→ 6 passed

### 実機デプロイ動作チェック
- `./deploy.sh` でデプロイ後、デプロイ先 bridge で `npm install --omit=dev` をクリーン実行 → **ws のみインストール**（eslint/jest/prettier は absent）、**deprecation 警告ゼロ**、**audit 0 件**を確認
- Max 再起動 → MCP 再接続後、[docs/integration-test-checklist.md](docs/integration-test-checklist.md) の**全 27 ツール統合テストを再実施 → 全 PASS（回帰なし）**

## 受け入れ基準

- [x] デプロイ時の出力に deprecation 警告が出ない（`--omit=dev` 化）
- [x] `npm audit --omit=dev` が 0 件（`ws` 更新後）
- [x] `package-lock.json` を更新・コミット
- [x] 別ブランチで対応

## スコープ外

- 方針 3（ESLint 8→9 / flat config 移行）は開発体験の改善で独立して進める想定のため、本 PR では対象外

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
