### PR TITLE
refactor(tools): unify coordinate pairs in utility_tools onto geometry::Point

### DIFF
--- a/src/tools/utility_tools.cpp
+++ b/src/tools/utility_tools.cpp
@@ -51,10 +51,9 @@ constexpr double PLACE_GAP = 8.0;            // minimum visual gap between objec
 constexpr double PLACE_GRID = 15.0;          // search step (matches Max default grid)
 constexpr double PLACE_MAX_RADIUS = 4000.0;  // give up beyond this many px
 
-struct Point {
-    double x;
-    double y;
-};
+// Reuse the shared geometry point so the placement search and the layout tools
+// speak the same coordinate type (see src/utils/geometry.h).
+using Point = geometry::Point;
 
 // A width x height rect at (x, y) is valid when it stays in the visible area
 // and clears every existing rect (keeping PLACE_GAP of separation).
@@ -133,18 +132,18 @@ PlacedPosition find_avoid_rect_position(const std::vector<Rect>& existing, doubl
     const Point anchor = search_anchor(existing, has_near, near_x, near_y, desc);
 
     if (position_is_free(anchor.x, anchor.y, width, height, existing)) {
-        return {anchor.x, anchor.y, "Placed " + desc};
+        return {anchor, "Placed " + desc};
     }
 
     Point spot{};
     for (double radius = PLACE_GRID; radius <= PLACE_MAX_RADIUS; radius += PLACE_GRID) {
         if (nearest_free_on_ring(anchor, radius, width, height, existing, spot)) {
-            return {spot.x, spot.y, "Found nearest free position " + desc};
+            return {spot, "Found nearest free position " + desc};
         }
     }
 
     // Fallback for an extremely dense patch: the far right is always free.
-    return {rightmost_edge(existing) + PLACE_MARGIN, 50.0, "Fallback: placed to the far right"};
+    return {{rightmost_edge(existing) + PLACE_MARGIN, 50.0}, "Fallback: placed to the far right"};
 }
 
 // ============================================================================
@@ -197,7 +196,7 @@ static void get_position_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_ato
                      std::to_string(static_cast<int>(data->height)) + ")";
     }
 
-    COMPLETE_DEFERRED(data, json({{"position", json::array({placed.x, placed.y})},
+    COMPLETE_DEFERRED(data, json({{"position", json::array({placed.position.x, placed.position.y})},
                                   {"width", data->width},
                                   {"height", data->height},
                                   {"rationale", rationale}}));

--- a/src/tools/utility_tools.h
+++ b/src/tools/utility_tools.h
@@ -43,8 +43,7 @@ using Rect = geometry::Rect;
  * @brief Result of a placement search.
  */
 struct PlacedPosition {
-    double x;
-    double y;
+    geometry::Point position;
     std::string rationale;
 };
 

--- a/tests/unit/test_avoid_rect_position.cpp
+++ b/tests/unit/test_avoid_rect_position.cpp
@@ -32,11 +32,12 @@ constexpr double kGap = 8.0;
 // boundary coverage).
 void expect_cleared(const PlacedPosition& placed, double width, double height,
                     const std::vector<Rect>& existing) {
-    const Rect r{placed.x, placed.y, width, height};
+    const Rect r{placed.position.x, placed.position.y, width, height};
     for (const Rect& e : existing) {
         EXPECT_FALSE(rects_conflict(r, e, kGap))
-            << "placed (" << placed.x << "," << placed.y << ") is within the gap of existing ("
-            << e.origin.x << "," << e.origin.y << "," << e.width << "," << e.height << ")";
+            << "placed (" << placed.position.x << "," << placed.position.y
+            << ") is within the gap of existing (" << e.origin.x << "," << e.origin.y << ","
+            << e.width << "," << e.height << ")";
     }
 }
 
@@ -92,8 +93,8 @@ TEST(RectsConflict, WithinGapOnlyConflictsWhenBothAxesClose) {
 // Empty patch, no anchor -> default origin (50, 50).
 TEST(AvoidRectPosition, EmptyPatchReturnsOrigin) {
     PlacedPosition p = find_avoid_rect_position({}, 50.0, 20.0, false, 0.0, 0.0);
-    EXPECT_DOUBLE_EQ(p.x, 50.0);
-    EXPECT_DOUBLE_EQ(p.y, 50.0);
+    EXPECT_DOUBLE_EQ(p.position.x, 50.0);
+    EXPECT_DOUBLE_EQ(p.position.y, 50.0);
     EXPECT_TRUE(contains(p.rationale, "origin")) << p.rationale;
 }
 
@@ -103,8 +104,8 @@ TEST(AvoidRectPosition, NoAnchorPlacesToTheRight) {
     std::vector<Rect> existing{{50.0, 50.0, 100.0, 22.0}};
     PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, false, 0.0, 0.0);
     // rightmost edge = 150, + margin 50 = 200
-    EXPECT_DOUBLE_EQ(p.x, 200.0);
-    EXPECT_DOUBLE_EQ(p.y, 50.0);
+    EXPECT_DOUBLE_EQ(p.position.x, 200.0);
+    EXPECT_DOUBLE_EQ(p.position.y, 50.0);
     EXPECT_TRUE(contains(p.rationale, "right")) << p.rationale;
     expect_cleared(p, 50.0, 20.0, existing);
 }
@@ -113,8 +114,8 @@ TEST(AvoidRectPosition, NoAnchorPlacesToTheRight) {
 TEST(AvoidRectPosition, FreeAnchorReturnedExactly) {
     std::vector<Rect> existing{{0.0, 0.0, 40.0, 40.0}};
     PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, true, 400.0, 300.0);
-    EXPECT_DOUBLE_EQ(p.x, 400.0);
-    EXPECT_DOUBLE_EQ(p.y, 300.0);
+    EXPECT_DOUBLE_EQ(p.position.x, 400.0);
+    EXPECT_DOUBLE_EQ(p.position.y, 300.0);
     EXPECT_TRUE(contains(p.rationale, "near")) << p.rationale;
     expect_cleared(p, 50.0, 20.0, existing);
 }
@@ -127,8 +128,8 @@ TEST(AvoidRectPosition, FreeAnchorReturnedExactly) {
 TEST(AvoidRectPosition, OccupiedAnchorPicksNearestFreeSpot) {
     std::vector<Rect> existing{{100.0, 100.0, 100.0, 40.0}};
     PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 120.0);
-    EXPECT_DOUBLE_EQ(p.x, 150.0);
-    EXPECT_DOUBLE_EQ(p.y, 150.0);
+    EXPECT_DOUBLE_EQ(p.position.x, 150.0);
+    EXPECT_DOUBLE_EQ(p.position.y, 150.0);
     EXPECT_TRUE(contains(p.rationale, "nearest")) << p.rationale;
     expect_cleared(p, 50.0, 20.0, existing);
 }
@@ -139,13 +140,14 @@ TEST(AvoidRectPosition, RespectsObjectSizeWhenFittingGaps) {
     std::vector<Rect> existing{{100.0, 100.0, 100.0, 40.0}, {100.0, 200.0, 100.0, 40.0}};
     // The gap spans y in [140, 200]; anchor at its middle.
     PlacedPosition small = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 170.0);
-    EXPECT_DOUBLE_EQ(small.x, 150.0);
-    EXPECT_DOUBLE_EQ(small.y, 170.0);  // 20px-tall object fits, anchor is already free
+    EXPECT_DOUBLE_EQ(small.position.x, 150.0);
+    EXPECT_DOUBLE_EQ(small.position.y, 170.0);  // 20px-tall object fits, anchor is already free
     expect_cleared(small, 50.0, 20.0, existing);
 
     PlacedPosition tall = find_avoid_rect_position(existing, 50.0, 80.0, true, 150.0, 170.0);
     // 80px tall cannot fit the 60px gap, so it is placed clear of both objects.
-    EXPECT_FALSE(tall.y >= 140.0 && tall.y + 80.0 <= 200.0) << "tall object squeezed into the gap";
+    EXPECT_FALSE(tall.position.y >= 140.0 && tall.position.y + 80.0 <= 200.0)
+        << "tall object squeezed into the gap";
     expect_cleared(tall, 50.0, 80.0, existing);
 }
 
@@ -165,8 +167,8 @@ TEST(AvoidRectPosition, ClearsAllInClusteredLayout) {
 TEST(AvoidRectPosition, AvoidsNegativeCoordinates) {
     std::vector<Rect> existing{{0.0, 0.0, 200.0, 200.0}};
     PlacedPosition p = find_avoid_rect_position(existing, 50.0, 20.0, true, -100.0, -100.0);
-    EXPECT_GE(p.x, 0.0);
-    EXPECT_GE(p.y, 0.0);
+    EXPECT_GE(p.position.x, 0.0);
+    EXPECT_GE(p.position.y, 0.0);
     expect_cleared(p, 50.0, 20.0, existing);
 }
 
@@ -175,6 +177,6 @@ TEST(AvoidRectPosition, IsDeterministic) {
     std::vector<Rect> existing{{100.0, 100.0, 100.0, 40.0}};
     PlacedPosition a = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 120.0);
     PlacedPosition b = find_avoid_rect_position(existing, 50.0, 20.0, true, 150.0, 120.0);
-    EXPECT_DOUBLE_EQ(a.x, b.x);
-    EXPECT_DOUBLE_EQ(a.y, b.y);
+    EXPECT_DOUBLE_EQ(a.position.x, b.position.x);
+    EXPECT_DOUBLE_EQ(a.position.y, b.position.y);
 }


### PR DESCRIPTION
## 概要

Issue #79 の対応。`utility_tools`（`get_avoid_rect_position` 関連）に残っていた座標ペアを、#76 で確立した `geometry::Point` ベースの座標表現に統一します。

**挙動は不変**（座標値・rationale 文字列・JSON 出力形状をすべて維持）で、型表現の統一のみが目的です。

## 変更内容

- `PlacedPosition` を `double x; double y;` から `geometry::Point position;` に変更
- 匿名名前空間の重複 `struct Point { double x; double y; }` を `using Point = geometry::Point;` に置換して重複型を解消
- 追従修正:
  - `find_avoid_rect_position` の return 文（Point 変数をそのまま渡す／座標から構築する箇所は `{{x,y}, "..."}` で明示）
  - `get_position_deferred` の JSON 出力（`placed.position.x/.y`）
  - テストの `p.x/.y` → `p.position.x/.y`

JSON 出力キー（`position` 配列）は API 互換のため変更していません。

## 検証

- ✅ `./build.sh --test`：全 168 テスト緑
- ✅ clang-format 差分ゼロ
- ✅ コードレビュー（pr-review-toolkit:code-reviewer）：critical/important 指摘なし
- ✅ **実機統合テスト（27 MCP ツール全件）合格** — `get_avoid_rect_position` の right/near/nearest/size/clamp 全パターンで座標値・rationale・JSON 形状が従来どおりであることを Max 実機で確認

## チェックリスト対応（Issue #79）

- [x] `utility_tools.h` の `PlacedPosition` を `geometry::Point` ベースに
- [x] `utility_tools.cpp` 匿名名前空間の `struct Point` 重複を解消
- [x] テストの `EXPECT_DOUBLE_EQ(p.x, ...)` → `p.position.x` 置換
- [x] JSON 出力キー（`position` 配列）の API 互換を維持
- [x] `./build.sh --test` 全テスト緑

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)