### PR TITLE
refactor(tools): split pure layout checks into layout_checks.{h,cpp}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ set(TOOLS_SRC
     src/tools/hierarchy_tools.h
     src/tools/utility_tools.cpp
     src/tools/utility_tools.h
+    src/tools/layout_checks.cpp
+    src/tools/layout_checks.h
     src/tools/layout_tools.cpp
     src/tools/layout_tools.h
 )

--- a/src/tools/layout_checks.cpp
+++ b/src/tools/layout_checks.cpp
@@ -1,0 +1,243 @@
+/**
+    @file layout_checks.cpp
+    MaxMCP - Pure layout-check logic implementation
+
+    Implements run_layout_checks() and its per-check helpers over already-extracted
+    LayoutObject / LayoutCord structs. Max-API independent: the geometric decisions
+    delegate to src/utils/geometry.h, and the SDK glue that walks the patcher lives
+    in layout_tools.cpp.
+
+    @ingroup maxmcp
+*/
+
+#include "layout_checks.h"
+
+#include "utils/geometry.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace LayoutTools {
+
+// ============================================================================
+// Formatting helpers
+// ============================================================================
+
+namespace {
+
+// One-decimal coordinate, e.g. "876.8" — matches the precision used in spec
+// findings without dumping the full double precision.
+std::string fmt1(double v) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.1f", v);
+    return buf;
+}
+
+// Rounded integer string, for areas and overlap-region bounds.
+std::string fmti(double v) {
+    return std::to_string(static_cast<long>(std::llround(v)));
+}
+
+// A human-readable label for an object: its varname, or maxclass#id when unnamed.
+std::string label_for(const LayoutObject& o) {
+    if (!o.varname.empty()) {
+        return o.varname;
+    }
+    return o.maxclass + "#" + std::to_string(o.id);
+}
+
+// The {src_varname, outlet, dst_varname, inlet} topology block for a cord.
+json cord_topology(const LayoutCord& c) {
+    return {{"src_varname", c.src_varname},
+            {"outlet", c.outlet},
+            {"dst_varname", c.dst_varname},
+            {"inlet", c.inlet}};
+}
+
+// Each append_*_findings helper runs one check, pushes its findings onto
+// `findings`, and returns how many it added (for the summary counters). Splitting
+// the checks out keeps run_layout_checks a flat orchestrator instead of a deeply
+// nested loop nest.
+
+// overlap / presentation_overlap: every overlapping object pair (AABB). The mode
+// only changes the label and which counter the caller credits the count to.
+int append_overlap_findings(const std::vector<LayoutObject>& objects,
+                            const LayoutCheckOptions& options, json& findings) {
+    const double eps = options.epsilon;
+    const std::string type = options.presentation_mode ? "presentation_overlap" : "overlap";
+    const std::string rect_name = options.presentation_mode ? "presentation_rect" : "patching_rect";
+    int count = 0;
+    for (size_t i = 0; i < objects.size(); ++i) {
+        for (size_t j = i + 1; j < objects.size(); ++j) {
+            const geometry::Rect& a = objects[i].rect;
+            const geometry::Rect& b = objects[j].rect;
+            if (!geometry::aabb_overlap(a, b, eps)) {
+                continue;
+            }
+            // aabb_overlap returned true, so the intersection has positive extent.
+            const geometry::Rect ov = geometry::aabb_intersection(a, b);
+            const double area = ov.area();
+            std::string detail = rect_name + " overlap area " + fmti(area) +
+                                 " px^2 (x:" + fmti(ov.origin.x) + "-" + fmti(ov.right()) +
+                                 " y:" + fmti(ov.origin.y) + "-" + fmti(ov.bottom()) + ")";
+            findings.push_back(
+                {{"type", type},
+                 {"severity", "error"},
+                 {"objects", json::array({label_for(objects[i]), label_for(objects[j])})},
+                 {"detail", detail}});
+            ++count;
+        }
+    }
+    return count;
+}
+
+// upward: a cord segment that rises on screen. A straight (no-midpoint) upward
+// cord is an error; an upward segment of a folded cord is an intentional detour
+// (warning).
+int append_upward_findings(const std::vector<LayoutCord>& cords, double eps, json& findings) {
+    int count = 0;
+    for (const LayoutCord& cord : cords) {
+        const std::vector<geometry::Segment> segs = cord.segments();
+        const bool has_midpoints = !cord.midpoints.empty();
+        for (const geometry::Segment& seg : segs) {
+            if (!geometry::segment_is_upward(seg, eps)) {
+                continue;
+            }
+            std::string detail = "start.y " + fmti(seg.a.y) + " > end.y " + fmti(seg.b.y) +
+                                 ", num_midpoints " + std::to_string(cord.midpoints.size());
+            findings.push_back({{"type", "upward"},
+                                {"severity", has_midpoints ? "warning" : "error"},
+                                {"cord", cord_topology(cord)},
+                                {"detail", detail}});
+            ++count;
+        }
+    }
+    return count;
+}
+
+// cord_object: a cord segment passing through an unrelated object's rect. The
+// cord's own source/destination objects are excluded, and each (cord, object)
+// pair is reported at most once.
+int append_cord_object_findings(const std::vector<LayoutObject>& objects,
+                                const std::vector<LayoutCord>& cords, double eps, json& findings) {
+    int count = 0;
+    for (const LayoutCord& cord : cords) {
+        const std::vector<geometry::Segment> segs = cord.segments();
+        std::set<int> already_flagged;
+        for (const geometry::Segment& seg : segs) {
+            for (const LayoutObject& obj : objects) {
+                if (obj.id == cord.src_id || obj.id == cord.dst_id) {
+                    continue;  // a cord may legitimately touch its own endpoints
+                }
+                if (already_flagged.count(obj.id)) {
+                    continue;
+                }
+                geometry::Point entry{0.0, 0.0};
+                if (!geometry::segment_intersects_rect(seg, obj.rect, eps, &entry)) {
+                    continue;
+                }
+                already_flagged.insert(obj.id);
+                std::string detail = "cord segment passes through object rect; crossing at (" +
+                                     fmt1(entry.x) + ", " + fmt1(entry.y) + ")";
+                findings.push_back({{"type", "cord_object"},
+                                    {"severity", "error"},
+                                    {"cord", cord_topology(cord)},
+                                    {"object", label_for(obj)},
+                                    {"detail", detail}});
+                ++count;
+            }
+        }
+    }
+    return count;
+}
+
+// cord_cord: two cords whose axis-aligned segments collinearly overlap. Each cord
+// pair is reported at most once.
+int append_cord_cord_findings(const std::vector<LayoutCord>& cords, double eps, json& findings) {
+    // Flatten every cord into (cord index, segment) for pairwise testing.
+    struct IndexedSegment {
+        size_t cord;
+        geometry::Segment seg;
+    };
+    std::vector<IndexedSegment> all_segments;
+    for (size_t ci = 0; ci < cords.size(); ++ci) {
+        for (const geometry::Segment& seg : cords[ci].segments()) {
+            all_segments.push_back({ci, seg});
+        }
+    }
+    std::set<std::pair<size_t, size_t>> flagged_pairs;
+    int count = 0;
+    for (size_t a = 0; a < all_segments.size(); ++a) {
+        for (size_t b = a + 1; b < all_segments.size(); ++b) {
+            if (all_segments[a].cord == all_segments[b].cord) {
+                continue;  // ignore a cord overlapping itself
+            }
+            if (!geometry::segments_overlap_collinear(all_segments[a].seg, all_segments[b].seg,
+                                                      eps)) {
+                continue;
+            }
+            const size_t ca = std::min(all_segments[a].cord, all_segments[b].cord);
+            const size_t cb = std::max(all_segments[a].cord, all_segments[b].cord);
+            if (!flagged_pairs.insert({ca, cb}).second) {
+                continue;
+            }
+            findings.push_back(
+                {{"type", "cord_cord"},
+                 {"severity", "warning"},
+                 {"cords", json::array({cord_topology(cords[ca]), cord_topology(cords[cb])})},
+                 {"detail", "collinear cord segments overlap"}});
+            ++count;
+        }
+    }
+    return count;
+}
+
+}  // namespace
+
+// ============================================================================
+// Pure check orchestration (Max-API independent)
+// ============================================================================
+
+json run_layout_checks(const std::vector<LayoutObject>& objects,
+                       const std::vector<LayoutCord>& cords, const LayoutCheckOptions& options) {
+    const double eps = options.epsilon;
+    json findings = json::array();
+    int n_upward = 0, n_overlap = 0, n_cord_object = 0, n_cord_cord = 0, n_presentation = 0;
+
+    // Object overlaps apply in both modes; the mode only decides the label and
+    // which summary counter the count lands in.
+    if (options.check_overlap) {
+        const int overlaps = append_overlap_findings(objects, options, findings);
+        (options.presentation_mode ? n_presentation : n_overlap) += overlaps;
+    }
+
+    // Cords are not drawn in presentation mode, so cord-based checks run only for
+    // the patching layout.
+    if (!options.presentation_mode) {
+        if (options.check_upward) {
+            n_upward += append_upward_findings(cords, eps, findings);
+        }
+        if (options.check_cord_object) {
+            n_cord_object += append_cord_object_findings(objects, cords, eps, findings);
+        }
+        if (options.check_cord_cord) {
+            n_cord_cord += append_cord_cord_findings(cords, eps, findings);
+        }
+    }
+
+    return {{"clean", findings.empty()},
+            {"summary",
+             {{"upward", n_upward},
+              {"overlap", n_overlap},
+              {"cord_object", n_cord_object},
+              {"cord_cord", n_cord_cord},
+              {"presentation_overlap", n_presentation}}},
+            {"findings", findings}};
+}
+
+}  // namespace LayoutTools

--- a/src/tools/layout_checks.h
+++ b/src/tools/layout_checks.h
@@ -1,0 +1,105 @@
+/**
+    @file layout_checks.h
+    MaxMCP - Pure layout-check logic (Max-API independent)
+
+    The data structures and finding orchestration behind validate_layout, with no
+    Max SDK dependency so they can be unit-tested directly. A patcher is reduced to
+    plain LayoutObject / LayoutCord structs (by the SDK glue in layout_tools.cpp),
+    then run_layout_checks() applies the geometric predicates from
+    src/utils/geometry.h and returns the structured findings list.
+
+    @ingroup maxmcp
+*/
+
+#ifndef LAYOUT_CHECKS_H
+#define LAYOUT_CHECKS_H
+
+#include "utils/geometry.h"
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace LayoutTools {
+
+using json = nlohmann::json;
+
+// ============================================================================
+// Plain data extracted from a patcher (Max-API independent, testable)
+// ============================================================================
+
+/**
+ * @brief One object's geometry, as needed by the layout checks.
+ *
+ * @c id is the object's position in patcher order; it identifies cord endpoints
+ * unambiguously even when objects share (or lack) a varname. @c rect is the rect
+ * for the active mode (patching or presentation).
+ */
+struct LayoutObject {
+    int id;
+    std::string varname;
+    std::string maxclass;
+    geometry::Rect rect;
+    bool in_presentation;
+};
+
+/**
+ * @brief One patchcord's topology and polyline geometry.
+ *
+ * @c src_id / @c dst_id reference LayoutObject::id so cord-vs-object checks can
+ * skip the cord's own endpoints reliably.
+ */
+struct LayoutCord {
+    int src_id;
+    std::string src_varname;
+    long outlet;
+    int dst_id;
+    std::string dst_varname;
+    long inlet;
+    geometry::Point start;
+    geometry::Point end;
+    std::vector<geometry::Point> midpoints;
+
+    // The cord's polyline (start -> midpoints... -> end) decomposed into segments.
+    std::vector<geometry::Segment> segments() const {
+        return geometry::polyline_to_segments(start, midpoints, end);
+    }
+};
+
+/**
+ * @brief Which checks to run and with what tolerance.
+ */
+struct LayoutCheckOptions {
+    double epsilon = 2.0;
+    bool check_upward = true;
+    bool check_overlap = true;
+    bool check_cord_object = true;
+    bool check_cord_cord = true;
+    // When true, overlap findings are reported as "presentation_overlap" and the
+    // cord-based checks are skipped (cords are not shown in presentation mode).
+    bool presentation_mode = false;
+};
+
+// ============================================================================
+// Pure check orchestration (Max-API independent, unit-tested)
+// ============================================================================
+
+/**
+ * @brief Run the enabled layout checks over already-extracted geometry.
+ *
+ * Pure function: takes plain structs (no Max SDK) and returns the validate_layout
+ * response body { clean, summary, findings }. The geometric decisions are
+ * delegated to src/utils/geometry.h.
+ *
+ * @param objects Objects participating in the checks (rects for the active mode)
+ * @param cords   Patchcords participating in the checks
+ * @param options Enabled checks and tolerance
+ * @return JSON object: { "clean": bool, "summary": {...}, "findings": [...] }
+ */
+json run_layout_checks(const std::vector<LayoutObject>& objects,
+                       const std::vector<LayoutCord>& cords, const LayoutCheckOptions& options);
+
+}  // namespace LayoutTools
+
+#endif  // LAYOUT_CHECKS_H

--- a/src/tools/layout_tools.cpp
+++ b/src/tools/layout_tools.cpp
@@ -2,9 +2,10 @@
     @file layout_tools.cpp
     MaxMCP - Layout Validation MCP Tools Implementation
 
-    Implements validate_layout: walks a patcher for object rects and patchline
-    geometry, then runs the pure checks in run_layout_checks() (which delegate to
-    src/utils/geometry.h). Read-only — never mutates the patch.
+    Max-facing glue for validate_layout: walks a patcher for object rects and
+    patchline geometry, then runs the pure checks in run_layout_checks() (defined
+    in layout_checks.cpp, which delegates to src/utils/geometry.h). Read-only —
+    never mutates the patch.
 
     @ingroup maxmcp
 */
@@ -13,9 +14,6 @@
 
 #include "tool_common.h"
 
-#include <algorithm>
-#include <cmath>
-#include <cstdio>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -37,222 +35,6 @@
 namespace LayoutTools {
 
 using ToolCommon::DeferredResult;
-
-// ============================================================================
-// Formatting helpers
-// ============================================================================
-
-namespace {
-
-// One-decimal coordinate, e.g. "876.8" — matches the precision used in spec
-// findings without dumping the full double precision.
-std::string fmt1(double v) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "%.1f", v);
-    return buf;
-}
-
-// Rounded integer string, for areas and overlap-region bounds.
-std::string fmti(double v) {
-    return std::to_string(static_cast<long>(std::llround(v)));
-}
-
-// A human-readable label for an object: its varname, or maxclass#id when unnamed.
-std::string label_for(const LayoutObject& o) {
-    if (!o.varname.empty()) {
-        return o.varname;
-    }
-    return o.maxclass + "#" + std::to_string(o.id);
-}
-
-// The {src_varname, outlet, dst_varname, inlet} topology block for a cord.
-json cord_topology(const LayoutCord& c) {
-    return {{"src_varname", c.src_varname},
-            {"outlet", c.outlet},
-            {"dst_varname", c.dst_varname},
-            {"inlet", c.inlet}};
-}
-
-// Each append_*_findings helper runs one check, pushes its findings onto
-// `findings`, and returns how many it added (for the summary counters). Splitting
-// the checks out keeps run_layout_checks a flat orchestrator instead of a deeply
-// nested loop nest.
-
-// overlap / presentation_overlap: every overlapping object pair (AABB). The mode
-// only changes the label and which counter the caller credits the count to.
-int append_overlap_findings(const std::vector<LayoutObject>& objects,
-                            const LayoutCheckOptions& options, json& findings) {
-    const double eps = options.epsilon;
-    const std::string type = options.presentation_mode ? "presentation_overlap" : "overlap";
-    const std::string rect_name = options.presentation_mode ? "presentation_rect" : "patching_rect";
-    int count = 0;
-    for (size_t i = 0; i < objects.size(); ++i) {
-        for (size_t j = i + 1; j < objects.size(); ++j) {
-            const geometry::Rect& a = objects[i].rect;
-            const geometry::Rect& b = objects[j].rect;
-            if (!geometry::aabb_overlap(a, b, eps)) {
-                continue;
-            }
-            // aabb_overlap returned true, so the intersection has positive extent.
-            const geometry::Rect ov = geometry::aabb_intersection(a, b);
-            const double area = ov.area();
-            std::string detail = rect_name + " overlap area " + fmti(area) +
-                                 " px^2 (x:" + fmti(ov.origin.x) + "-" + fmti(ov.right()) +
-                                 " y:" + fmti(ov.origin.y) + "-" + fmti(ov.bottom()) + ")";
-            findings.push_back(
-                {{"type", type},
-                 {"severity", "error"},
-                 {"objects", json::array({label_for(objects[i]), label_for(objects[j])})},
-                 {"detail", detail}});
-            ++count;
-        }
-    }
-    return count;
-}
-
-// upward: a cord segment that rises on screen. A straight (no-midpoint) upward
-// cord is an error; an upward segment of a folded cord is an intentional detour
-// (warning).
-int append_upward_findings(const std::vector<LayoutCord>& cords, double eps, json& findings) {
-    int count = 0;
-    for (const LayoutCord& cord : cords) {
-        const std::vector<geometry::Segment> segs = cord.segments();
-        const bool has_midpoints = !cord.midpoints.empty();
-        for (const geometry::Segment& seg : segs) {
-            if (!geometry::segment_is_upward(seg, eps)) {
-                continue;
-            }
-            std::string detail = "start.y " + fmti(seg.a.y) + " > end.y " + fmti(seg.b.y) +
-                                 ", num_midpoints " + std::to_string(cord.midpoints.size());
-            findings.push_back({{"type", "upward"},
-                                {"severity", has_midpoints ? "warning" : "error"},
-                                {"cord", cord_topology(cord)},
-                                {"detail", detail}});
-            ++count;
-        }
-    }
-    return count;
-}
-
-// cord_object: a cord segment passing through an unrelated object's rect. The
-// cord's own source/destination objects are excluded, and each (cord, object)
-// pair is reported at most once.
-int append_cord_object_findings(const std::vector<LayoutObject>& objects,
-                                const std::vector<LayoutCord>& cords, double eps, json& findings) {
-    int count = 0;
-    for (const LayoutCord& cord : cords) {
-        const std::vector<geometry::Segment> segs = cord.segments();
-        std::set<int> already_flagged;
-        for (const geometry::Segment& seg : segs) {
-            for (const LayoutObject& obj : objects) {
-                if (obj.id == cord.src_id || obj.id == cord.dst_id) {
-                    continue;  // a cord may legitimately touch its own endpoints
-                }
-                if (already_flagged.count(obj.id)) {
-                    continue;
-                }
-                geometry::Point entry{0.0, 0.0};
-                if (!geometry::segment_intersects_rect(seg, obj.rect, eps, &entry)) {
-                    continue;
-                }
-                already_flagged.insert(obj.id);
-                std::string detail = "cord segment passes through object rect; crossing at (" +
-                                     fmt1(entry.x) + ", " + fmt1(entry.y) + ")";
-                findings.push_back({{"type", "cord_object"},
-                                    {"severity", "error"},
-                                    {"cord", cord_topology(cord)},
-                                    {"object", label_for(obj)},
-                                    {"detail", detail}});
-                ++count;
-            }
-        }
-    }
-    return count;
-}
-
-// cord_cord: two cords whose axis-aligned segments collinearly overlap. Each cord
-// pair is reported at most once.
-int append_cord_cord_findings(const std::vector<LayoutCord>& cords, double eps, json& findings) {
-    // Flatten every cord into (cord index, segment) for pairwise testing.
-    struct IndexedSegment {
-        size_t cord;
-        geometry::Segment seg;
-    };
-    std::vector<IndexedSegment> all_segments;
-    for (size_t ci = 0; ci < cords.size(); ++ci) {
-        for (const geometry::Segment& seg : cords[ci].segments()) {
-            all_segments.push_back({ci, seg});
-        }
-    }
-    std::set<std::pair<size_t, size_t>> flagged_pairs;
-    int count = 0;
-    for (size_t a = 0; a < all_segments.size(); ++a) {
-        for (size_t b = a + 1; b < all_segments.size(); ++b) {
-            if (all_segments[a].cord == all_segments[b].cord) {
-                continue;  // ignore a cord overlapping itself
-            }
-            if (!geometry::segments_overlap_collinear(all_segments[a].seg, all_segments[b].seg,
-                                                      eps)) {
-                continue;
-            }
-            const size_t ca = std::min(all_segments[a].cord, all_segments[b].cord);
-            const size_t cb = std::max(all_segments[a].cord, all_segments[b].cord);
-            if (!flagged_pairs.insert({ca, cb}).second) {
-                continue;
-            }
-            findings.push_back(
-                {{"type", "cord_cord"},
-                 {"severity", "warning"},
-                 {"cords", json::array({cord_topology(cords[ca]), cord_topology(cords[cb])})},
-                 {"detail", "collinear cord segments overlap"}});
-            ++count;
-        }
-    }
-    return count;
-}
-
-}  // namespace
-
-// ============================================================================
-// Pure check orchestration (Max-API independent)
-// ============================================================================
-
-json run_layout_checks(const std::vector<LayoutObject>& objects,
-                       const std::vector<LayoutCord>& cords, const LayoutCheckOptions& options) {
-    const double eps = options.epsilon;
-    json findings = json::array();
-    int n_upward = 0, n_overlap = 0, n_cord_object = 0, n_cord_cord = 0, n_presentation = 0;
-
-    // Object overlaps apply in both modes; the mode only decides the label and
-    // which summary counter the count lands in.
-    if (options.check_overlap) {
-        const int overlaps = append_overlap_findings(objects, options, findings);
-        (options.presentation_mode ? n_presentation : n_overlap) += overlaps;
-    }
-
-    // Cords are not drawn in presentation mode, so cord-based checks run only for
-    // the patching layout.
-    if (!options.presentation_mode) {
-        if (options.check_upward) {
-            n_upward += append_upward_findings(cords, eps, findings);
-        }
-        if (options.check_cord_object) {
-            n_cord_object += append_cord_object_findings(objects, cords, eps, findings);
-        }
-        if (options.check_cord_cord) {
-            n_cord_cord += append_cord_cord_findings(cords, eps, findings);
-        }
-    }
-
-    return {{"clean", findings.empty()},
-            {"summary",
-             {{"upward", n_upward},
-              {"overlap", n_overlap},
-              {"cord_object", n_cord_object},
-              {"cord_cord", n_cord_cord},
-              {"presentation_overlap", n_presentation}}},
-            {"findings", findings}};
-}
 
 // ============================================================================
 // Data Structures for Deferred Callbacks

--- a/src/tools/layout_tools.h
+++ b/src/tools/layout_tools.h
@@ -7,10 +7,11 @@
       cords, cord-vs-object crossings, collinear cord overlaps) and return a
       structured findings list. Read-only — never modifies the patch.
 
-    The geometric predicates live in src/utils/geometry.h (Max-API independent,
-    unit-tested). The finding orchestration in run_layout_checks() is likewise
-    Max-independent so it can be tested without the SDK; only the data extraction
-    (walking the patcher for rects and patchlines) needs the Max main thread.
+    This header is the Max-facing glue: the MCP dispatch and schema. The plain data
+    structures (LayoutObject / LayoutCord / LayoutCheckOptions) and the pure check
+    orchestration (run_layout_checks) live in layout_checks.h, Max-API independent
+    and unit-tested; only the data extraction (walking the patcher for rects and
+    patchlines) needs the Max main thread.
 
     @ingroup maxmcp
 */
@@ -18,10 +19,9 @@
 #ifndef LAYOUT_TOOLS_H
 #define LAYOUT_TOOLS_H
 
-#include "utils/geometry.h"
+#include "layout_checks.h"
 
 #include <string>
-#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -32,81 +32,6 @@ typedef struct _maxmcp t_maxmcp;
 namespace LayoutTools {
 
 using json = nlohmann::json;
-
-// ============================================================================
-// Plain data extracted from a patcher (Max-API independent, testable)
-// ============================================================================
-
-/**
- * @brief One object's geometry, as needed by the layout checks.
- *
- * @c id is the object's position in patcher order; it identifies cord endpoints
- * unambiguously even when objects share (or lack) a varname. @c rect is the rect
- * for the active mode (patching or presentation).
- */
-struct LayoutObject {
-    int id;
-    std::string varname;
-    std::string maxclass;
-    geometry::Rect rect;
-    bool in_presentation;
-};
-
-/**
- * @brief One patchcord's topology and polyline geometry.
- *
- * @c src_id / @c dst_id reference LayoutObject::id so cord-vs-object checks can
- * skip the cord's own endpoints reliably.
- */
-struct LayoutCord {
-    int src_id;
-    std::string src_varname;
-    long outlet;
-    int dst_id;
-    std::string dst_varname;
-    long inlet;
-    geometry::Point start;
-    geometry::Point end;
-    std::vector<geometry::Point> midpoints;
-
-    // The cord's polyline (start -> midpoints... -> end) decomposed into segments.
-    std::vector<geometry::Segment> segments() const {
-        return geometry::polyline_to_segments(start, midpoints, end);
-    }
-};
-
-/**
- * @brief Which checks to run and with what tolerance.
- */
-struct LayoutCheckOptions {
-    double epsilon = 2.0;
-    bool check_upward = true;
-    bool check_overlap = true;
-    bool check_cord_object = true;
-    bool check_cord_cord = true;
-    // When true, overlap findings are reported as "presentation_overlap" and the
-    // cord-based checks are skipped (cords are not shown in presentation mode).
-    bool presentation_mode = false;
-};
-
-// ============================================================================
-// Pure check orchestration (Max-API independent, unit-tested)
-// ============================================================================
-
-/**
- * @brief Run the enabled layout checks over already-extracted geometry.
- *
- * Pure function: takes plain structs (no Max SDK) and returns the validate_layout
- * response body { clean, summary, findings }. The geometric decisions are
- * delegated to src/utils/geometry.h.
- *
- * @param objects Objects participating in the checks (rects for the active mode)
- * @param cords   Patchcords participating in the checks
- * @param options Enabled checks and tolerance
- * @return JSON object: { "clean": bool, "summary": {...}, "findings": [...] }
- */
-json run_layout_checks(const std::vector<LayoutObject>& objects,
-                       const std::vector<LayoutCord>& cords, const LayoutCheckOptions& options);
 
 // ============================================================================
 // MCP tool interface

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SOURCES
     unit/test_console_logger.cpp
     unit/test_mcp_server.cpp
     unit/test_geometry.cpp
+    unit/test_layout_validate.cpp
 )
 
 # Utility source files (to be tested)
@@ -37,6 +38,7 @@ set(UTIL_SOURCES
     ../src/utils/patch_registry.cpp
     ../src/utils/patch_helpers.cpp
     ../src/utils/geometry.cpp
+    ../src/tools/layout_checks.cpp
 )
 
 # Create test executable
@@ -82,6 +84,7 @@ set(TOOL_SOURCES
     ../src/tools/state_tools.cpp
     ../src/tools/hierarchy_tools.cpp
     ../src/tools/utility_tools.cpp
+    ../src/tools/layout_checks.cpp
     ../src/tools/layout_tools.cpp
     ../src/utils/patch_helpers.cpp
     ../src/utils/geometry.cpp
@@ -91,7 +94,6 @@ set(TOOL_SOURCES
 add_executable(test_tool_routing
     unit/test_tool_routing.cpp
     unit/test_avoid_rect_position.cpp
-    unit/test_layout_validate.cpp
     ${TOOL_SOURCES}
     ../src/utils/console_logger.cpp
     ../src/utils/patch_registry.cpp

--- a/tests/unit/test_layout_validate.cpp
+++ b/tests/unit/test_layout_validate.cpp
@@ -8,7 +8,7 @@
     counters. The underlying geometry is covered separately in test_geometry.cpp.
 */
 
-#include "tools/layout_tools.h"
+#include "tools/layout_checks.h"
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
## 概要

Issue #80。`layout_tools.cpp` に同居していた**純粋な検査ロジック**と **Max SDK グルー**を物理的にファイル分離し、「純粋/グルー」の境界をファイルレベルで明示するとともに、テスト層を整える。

機能・API は不変（挙動完全互換）。

## 変更内容

| ファイル | 内容 |
|---|---|
| `src/tools/layout_checks.{h,cpp}`（新） | 純粋ロジック: `LayoutObject` / `LayoutCord` / `LayoutCheckOptions`、`append_*_findings` 群、`run_layout_checks`。依存は `utils/geometry.h` + nlohmann/json のみ（Max SDK 非依存） |
| `src/tools/layout_tools.{h,cpp}`（残） | SDK グルー: `extract_layout_objects/cords`、deferred callback、`execute_validate_layout`、schema、dispatch。`layout_checks.h` を include |
| `CMakeLists.txt` | `TOOLS_SRC` に `layout_checks.cpp` を追加 |
| `tests/CMakeLists.txt` | `test_layout_validate.cpp` を `test_tool_routing` から純粋ユニットの `maxmcp_tests` へ移動し、`layout_checks.cpp` を両ターゲットにリンク |
| `tests/unit/test_layout_validate.cpp` | include を `tools/layout_checks.h` に変更 |

## 実利（Issue #80 より）

- 純粋/グルーの境界が**ファイルとして明示**される（従来は anon namespace + `#ifndef MAXMCP_TEST_MODE` の慣習頼み）
- **テスト層の整理**: `run_layout_checks` の純粋テストが、SDK スタブ込みの `test_tool_routing` ではなく `geometry` と同じ純粋ユニット `maxmcp_tests` で回るようになり、「純粋→純粋テスト、グルー→ルーティングテスト」と層が揃う

## 検証

- `./build.sh --test --clean`: **168 テスト 100% pass**
- 9 個の `RunLayoutChecks.*` テストが純粋ターゲット `maxmcp_tests`（#101-109）で実行されることを確認
- clang-format クリーン
- `pr-review-toolkit:code-reviewer` によるレビュー通過（信頼度80以上の問題なし、挙動・API 不変を確認）
- **実機統合テスト**: デプロイ後、`docs/integration-test-checklist.md` の全 27 ツール（#27 validate_layout は #27〜#27j の全 11 ケース）を実機で完走し全項目合格

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)