### PR TITLE
feat(tools): add get_io_position MCP tool for inlet/outlet pixel positions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ npm run format:check
 - **`src/utils/`**: Shared utilities (UUID generator, console logger, patch registry, patch helpers)
 - *Note*: Legacy files `maxmcp_server.cpp`, `udp_server.cpp` from the earlier separate-external architecture have been removed
 
-### MCP Tools (27 total)
+### MCP Tools (28 total)
 
 Full tool reference with parameters and response formats: [docs/mcp-tools-reference.md](docs/mcp-tools-reference.md)
 
@@ -106,7 +106,7 @@ Full tool reference with parameters and response formats: [docs/mcp-tools-refere
 | Patch State | 3 | `get_patch_lock_state`, `set_patch_lock_state`, `get_patch_dirty` |
 | Hierarchy | 2 | `get_parent_patcher`, `get_subpatchers` |
 | Utilities | 2 | `get_console_log`, `get_avoid_rect_position` |
-| Layout Validation | 1 | `validate_layout` |
+| Layout Validation | 2 | `validate_layout`, `get_io_position` |
 
 ### Threading Model
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ set(UTILS_SRC
     src/utils/patch_helpers.h
     src/utils/geometry.cpp
     src/utils/geometry.h
+    src/utils/io_geometry.cpp
+    src/utils/io_geometry.h
 )
 
 # MCP Tool implementation files (extracted from mcp_server.cpp)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,7 +1,7 @@
 # MaxMCP Documentation Index
 
-**Last Updated**: 2026-06-03
-**Project Status**: 27 MCP Tools
+**Last Updated**: 2026-06-04
+**Project Status**: 28 MCP Tools
 
 ---
 
@@ -73,7 +73,7 @@ This index provides a comprehensive overview of all MaxMCP documentation.
 **Purpose**: Complete reference for all MCP tools
 **Audience**: Developers, users
 **Contents**:
-- All 27 MCP tools documentation
+- All 28 MCP tools documentation
 - Parameter specifications
 - Response formats
 - Error codes

--- a/docs/integration-test-checklist.md
+++ b/docs/integration-test-checklist.md
@@ -1,6 +1,6 @@
 # MCP Integration Test Checklist
 
-**Total Tools**: 27
+**Total Tools**: 28
 **Purpose**: Manual verification checklist for all MCP tools. Use before PR merges and releases.
 
 ---
@@ -78,7 +78,7 @@
 | 26c | `get_avoid_rect_position` | `width`/`height` of a large object    | Returned spot clears all objects by the gap for that size; rationale notes the size | [ ]  |
 | 26d | `get_avoid_rect_position` | Negative `near_x`/`near_y`            | Result clamped to non-negative coordinates (x ≥ 0, y ≥ 0)           | [ ]  |
 
-## Layout Validation (1)
+## Layout Validation (2)
 
 `validate_layout` is read-only. For each case, set up the patch state described, then run the tool and confirm the finding (or `clean`).
 
@@ -95,6 +95,17 @@
 | 27h | `validate_layout` | `mode: "presentation"` with overlapping `presentation_rect`         | `presentation_overlap` finding; cord checks skipped                                         | [ ]  |
 | 27i | `validate_layout` | `checks` subset (e.g. `["overlap"]`)                                | Only the requested check runs; others stay 0                                               | [ ]  |
 | 27j | `validate_layout` | Fix a reported finding, then re-run                                  | The finding disappears; repeat until `clean: true` (validate → fix → re-validate loop)     | [ ]  |
+
+`get_io_position` is read-only. The ground-truth cross-check is a connected cord's real endpoint (`get_patchlines mode:"geometry"` `start_point` for an outlet, `end_point` for an inlet).
+
+| #   | Tool              | Test                                                                 | Expected                                                                                   | Pass |
+|-----|-------------------|----------------------------------------------------------------------|--------------------------------------------------------------------------------------------|------|
+| 28  | `get_io_position` | `side:"inlet"` on a 2+ inlet object (e.g. `cycle~`)                  | `count` matches inlet count; `positions[i].y` = object top; x values match cord endpoints  | [ ]  |
+| 28a | `get_io_position` | `side:"outlet"` on a multi-outlet object (e.g. `number`, `live.gain~`) | `positions[i].y` = object bottom; x equally spaced, matches cord `start_point`s            | [ ]  |
+| 28b | `get_io_position` | Cross-check: connect a cord to inlet `i`, compare to `end_point`      | `positions[i]` agrees with the cord endpoint within ~1px                                    | [ ]  |
+| 28c | `get_io_position` | Tall object (`gain~`, `slider`)                                       | inlet y = top, outlet y = bottom (height handled); x uses the calibrated inset             | [ ]  |
+| 28d | `get_io_position` | Unknown `varname`                                                    | Error: "Object not found: <varname>"                                                        | [ ]  |
+| 28e | `get_io_position` | Invalid `side` (not inlet/outlet)                                    | Error: side must be "inlet" or "outlet"                                                      | [ ]  |
 
 ---
 

--- a/docs/layout-validation-tools-spec.md
+++ b/docs/layout-validation-tools-spec.md
@@ -2,7 +2,7 @@
 
 **作成日**: 2026-06-03
 **対象読者**: MaxMCP を開発する Claude / 開発者
-**ステータス**: 実装中（Section 7 の Step 1 `geometry.{h,cpp}` と Step 2 `validate_layout` は実装済み。Step 3 `get_io_position` 以降は未着手）
+**ステータス**: 実装中（Section 7 の Step 1 `geometry.{h,cpp}`、Step 2 `validate_layout`、Step 3 `get_io_position` は実装済み。Step 4 `suggest_alignment` 以降は未着手）
 
 ---
 
@@ -152,8 +152,15 @@ AI が毎回その場で計算している近似式 `pos_i = left + 9.5 + (w-19)
 - 計算: Max は inlet を上辺に、outlet を下辺に等間隔配置する。`n==1` は端から一定オフセット、`n>=2` は左端〜右端に等間隔。中心 x を算出して返す（上辺 y = `rect.y`、下辺 y = `rect.y + rect.height`）。
 - **定数の較正が必須**: inlet の視覚幅・端インセット（近似式の `9.5` / `19` に相当）は推測で固定せず、**代表的なオブジェクト（newobj、live.* UI、numbox 等）の実機 inlet 位置を測って決め、ユニットテストにフィクスチャとして焼き込む**。種別差（UI オブジェクトと newobj で見た目幅が違う）に注意。
 - `drawfirstin` が false の種別は視覚 inlet 数が論理数とずれるため補正する。
-- `validate_layout` の cord 端点座標も**この関数と同じ実装を共有**する（二重実装を避ける）。
+- `validate_layout` との関係（**実装時の確定事項**）: `validate_layout` は既存コードの cord 端点を `jpatchline_get_startpoint/endpoint`（Max の実座標＝グラウンドトゥルース）で取得しており、近似式より正確。よって**統合しない**。`get_io_position` の式は「未接続の nub の座標を算出する」用途のフォールバックであり、両者は `geometry::Rect/Point` という共通語彙を介して整合する。
 - 限界の明示: これは Max 内部描画の再現であり、Max 側の仕様変更で定数がずれる可能性がある。テストが回帰検出器になる。
+
+### 実装結果（2026-06-04, Max 9 で校正）
+
+- 代表 8 種（newobj `cycle~`/`pak`, `number`, `live.numbox`, `live.dial`, `gain~`, `slider`, `live.gain~`, `toggle`）をコード端点で実測した結果、**`edge_inset = single_inset = 9.5` が全種で普遍**。per-class テーブルは不要（`io_calibration_for` は将来の拡張フックとして空テーブルで保持）。
+- inlet y = `rect.y` / outlet y = `rect.bottom()` も普遍で、**縦長オブジェクトの特別扱いは不要**（高さは下辺に織り込まれる）。
+- 唯一の例外: 幅が極端に狭い場合（`gain~` 幅22px）に nub が ~0.5px 丸められる。幅を広げると消える。フィクスチャに記録済み。
+- 純粋実装は `src/utils/io_geometry.{h,cpp}`、フィクスチャは `tests/unit/test_io_geometry.cpp`、グルーは `src/tools/layout_tools.cpp`。
 
 ---
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -1,6 +1,6 @@
 # MaxMCP MCP Tools Reference
 
-**Last Updated**: 2026-06-03
+**Last Updated**: 2026-06-04
 
 This document provides a complete reference for all MCP tools available in MaxMCP.
 
@@ -8,7 +8,7 @@ This document provides a complete reference for all MCP tools available in MaxMC
 
 ## Overview
 
-MaxMCP provides 27 MCP tools for controlling Max/MSP patches through natural language commands. Tools are organized into categories based on their functionality.
+MaxMCP provides 28 MCP tools for controlling Max/MSP patches through natural language commands. Tools are organized into categories based on their functionality.
 
 ---
 
@@ -22,7 +22,7 @@ MaxMCP provides 27 MCP tools for controlling Max/MSP patches through natural lan
 | Patch State | 3 | Lock state and dirty flag management |
 | Hierarchy | 2 | Parent/child patcher navigation |
 | Utilities | 2 | Console logging and positioning |
-| Layout Validation | 1 | Machine-check layout geometry (overlaps, crossings) |
+| Layout Validation | 2 | Machine-check layout geometry, compute inlet/outlet positions |
 
 ---
 
@@ -830,6 +830,48 @@ findings until `clean` is `true`.
 
 An empty `findings` array means `clean` is `true`. The intended loop is:
 validate → fix findings → re-validate until clean.
+
+---
+
+### `get_io_position`
+
+Return the pixel center `(x, y)` of each inlet (top edge) or outlet (bottom edge)
+of an object. **Read-only**. Max's SDK exposes no getter for per-inlet/outlet
+coordinates, so the positions are computed by reproducing Max's equal-spacing
+placement rule; the calibration constant is measured on a real device and pinned
+by unit tests (`tests/unit/test_io_geometry.cpp`). Use this instead of
+hand-computing nub positions when aligning an outlet over an inlet or sizing an
+object so a given inlet lands at a target x.
+
+**Parameters**:
+```json
+{
+  "patch_id": {"type": "string", "required": true, "description": "Patch ID containing the object"},
+  "varname": {"type": "string", "required": true, "description": "Object varname to query"},
+  "side": {"type": "string", "required": true, "description": "'inlet' (top edge) or 'outlet' (bottom edge)"}
+}
+```
+
+**Response**:
+```json
+{
+  "result": {
+    "varname": "curve_scale",
+    "side": "inlet",
+    "count": 2,
+    "positions": [
+      {"index": 0, "x": 309.5, "y": 200.0},
+      {"index": 1, "x": 410.5, "y": 200.0}
+    ]
+  }
+}
+```
+
+**Notes**:
+- `index` is the **logical** inlet/outlet number — the same index `connect_max_objects` uses.
+- Inlets report `y = patching_rect.y`; outlets report `y = patching_rect.y + height`. This holds for tall objects (the height is already in the bottom edge).
+- The placement rule is exact for normal widths; for pathologically narrow objects (e.g. `gain~` at its native 22px width) Max rounds a nub by up to ~0.5px.
+- If the object's first inlet is not drawn (`jbox_get_drawfirstin` is false), that nub is omitted and the remaining inlets keep their logical indices (1..n-1).
 
 ---
 

--- a/plugins/maxmcp/skills/patch-guidelines/reference/layout-rules.md
+++ b/plugins/maxmcp/skills/patch-guidelines/reference/layout-rules.md
@@ -177,6 +177,8 @@ live.button (x=18)     trigger (x=18)
 
 **Rule**: Before adding midpoints, first try repositioning objects so that outlet and inlet share the same X coordinate.
 
+> **Do not hand-compute nub X positions.** The example's `x=27.5` is illustrative — actual inlet/outlet centers depend on the object's rect and nub count. Call the **`get_io_position`** MCP tool (`{patch_id, varname, side}`) to get the exact, calibrated `(x, y)` of each inlet/outlet instead of estimating with a formula.
+
 ### Width Adjustment for Straight Lines
 
 When two objects have multiple inlets/outlets connected (e.g., `filtercoeff~` → `biquad~`), adjust **object width** via `patching_rect` so that outlet and inlet X coordinates align, eliminating diagonal patchcords.
@@ -461,13 +463,17 @@ Example: t b i i, outlet 0 (near) and outlet 1 (far) expanding in the same direc
 
 This prevents horizontal segments from crossing each other.
 
-### Multi-Outlet Width Alignment Formula
+### Multi-Outlet Width Alignment
 
-When a multi-outlet object connects to multiple destinations, calculate the required width to align outlets with destination inlets:
+When a multi-outlet object connects to multiple destinations, you often want to
+size the source so its outlets line up over the destination inlets. **Do not
+hand-compute this with a `±9.5` inset formula** — the inset is calibrated and the
+spacing depends on the outlet count. Instead:
 
-```
-width = (rightmost_dest_x + 9.5) - source_x + 9.5
-```
+1. Call **`get_io_position`** on each destination (`side:"inlet"`) to get the exact target X of each inlet.
+2. Call **`get_io_position`** on the source (`side:"outlet"`) and adjust the source's `patching_rect` width until the outlet X values land on those targets (re-query after resizing).
+
+This replaces the old approximation `width = (rightmost_dest_x + 9.5) - source_x + 9.5`, which ignored per-object inset differences.
 
 - For `route` or other high-outlet-count objects, prioritize vertical alignment for the most connections. Accept diagonal for structurally unavoidable crossings.
 - The main flow's vertical alignment takes precedence — move downstream/branch objects to align, not the main flow objects.

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -93,6 +93,7 @@ void MCPServer::stop() {
  * - StateTools (3 tools)
  * - HierarchyTools (2 tools)
  * - UtilityTools (2 tools)
+ * - LayoutTools (2 tools)
  *
  * @return JSON array of all tool schemas
  */

--- a/src/tools/layout_tools.cpp
+++ b/src/tools/layout_tools.cpp
@@ -29,6 +29,7 @@
 #include "maxmcp.h"
 #include "utils/console_logger.h"
 #include "utils/geometry.h"
+#include "utils/io_geometry.h"
 #include "utils/patch_helpers.h"
 #include "utils/patch_registry.h"
 
@@ -44,6 +45,13 @@ struct t_validate_layout_data {
     t_maxmcp* patch;
     LayoutCheckOptions options;
     std::vector<std::string> scope_varnames;
+    DeferredResult* deferred_result;
+};
+
+struct t_get_io_position_data {
+    t_maxmcp* patch;
+    std::string varname;
+    geometry::IoSide side;
     DeferredResult* deferred_result;
 };
 
@@ -243,6 +251,92 @@ static json execute_validate_layout(const json& params) {
     return {{"result", result}};
 }
 
+/**
+ * Deferred callback for get_io_position.
+ * Executes on the Max main thread via defer(). Reads the box rect, counts, and
+ * drawfirstin, then delegates to the pure placement rule in io_geometry.h.
+ */
+static void get_io_position_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_atom* argv) {
+    VALIDATE_DEFERRED_ARGS("get_io_position_deferred");
+    EXTRACT_DEFERRED_DATA_WITH_RESULT(t_get_io_position_data, data, argv);
+
+    t_object* box = PatchHelpers::find_box_by_varname(data->patch->patcher, data->varname);
+    if (!box) {
+        COMPLETE_DEFERRED(data, ToolCommon::object_not_found_error(data->varname));
+        return;
+    }
+
+    t_rect rect;
+    jbox_get_patching_rect(box, &rect);
+    const geometry::Rect box_rect{rect.x, rect.y, rect.width, rect.height};
+
+    const bool is_inlet = (data->side == geometry::IoSide::Inlet);
+    const long logical_count =
+        is_inlet ? PatchHelpers::get_inlet_count(box) : PatchHelpers::get_outlet_count(box);
+    // drawfirstin only suppresses an inlet nub; outlets always draw every nub.
+    const bool draw_first_in = is_inlet ? (jbox_get_drawfirstin(box) != 0) : true;
+    const std::string maxclass = PatchHelpers::get_box_maxclass(box);
+
+    const std::vector<geometry::IoPosition> io = geometry::io_positions(
+        box_rect, static_cast<int>(logical_count), data->side, draw_first_in, maxclass);
+
+    json positions = json::array();
+    for (const geometry::IoPosition& p : io) {
+        positions.push_back({{"index", p.index}, {"x", p.center.x}, {"y", p.center.y}});
+    }
+
+    COMPLETE_DEFERRED(data, (json{{"varname", data->varname},
+                                  {"side", is_inlet ? "inlet" : "outlet"},
+                                  {"count", positions.size()},
+                                  {"positions", positions}}));
+}
+
+/**
+ * Execute get_io_position tool.
+ */
+static json execute_get_io_position(const json& params) {
+    std::string patch_id = params.value("patch_id", "");
+    std::string varname = params.value("varname", "");
+    std::string side_str = params.value("side", "");
+
+    if (patch_id.empty() || varname.empty() || side_str.empty()) {
+        return ToolCommon::make_error(ToolCommon::ErrorCode::INVALID_PARAMS,
+                                      "Missing required parameters: patch_id, varname, and side");
+    }
+    if (side_str != "inlet" && side_str != "outlet") {
+        return ToolCommon::make_error(ToolCommon::ErrorCode::INVALID_PARAMS,
+                                      "side must be \"inlet\" or \"outlet\"");
+    }
+
+    t_maxmcp* patch = PatchRegistry::find_patch(patch_id);
+    if (!patch) {
+        return ToolCommon::patch_not_found_error(patch_id);
+    }
+
+    const geometry::IoSide side =
+        (side_str == "inlet") ? geometry::IoSide::Inlet : geometry::IoSide::Outlet;
+
+    auto* deferred_result = new DeferredResult();
+    auto* data = new t_get_io_position_data{patch, varname, side, deferred_result};
+
+    t_atom a;
+    atom_setobj(&a, data);
+    defer(patch, (method)get_io_position_deferred, gensym("get_io_position"), 1, &a);
+
+    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
+        delete deferred_result;
+        return ToolCommon::timeout_error("getting io position");
+    }
+
+    json result = deferred_result->result;
+    delete deferred_result;
+
+    if (result.contains("error")) {
+        return result;
+    }
+    return {{"result", result}};
+}
+
 #endif  // MAXMCP_TEST_MODE
 
 // ============================================================================
@@ -283,7 +377,23 @@ json get_tool_schemas() {
               {"epsilon",
                {{"type", "number"},
                 {"description", "Tolerance in pixels for all checks (default: 2.0)."}}}}},
-            {"required", json::array({"patch_id"})}}}}});
+            {"required", json::array({"patch_id"})}}}},
+         {{"name", "get_io_position"},
+          {"description",
+           "Return the pixel center (x, y) of each inlet (top edge) or outlet (bottom edge) "
+           "of an object, computed with Max's calibrated equal-spacing rule. Use instead of "
+           "hand-computing nub x positions for width/alignment work. 'index' is the logical "
+           "inlet/outlet number (matches connect_max_objects)."},
+          {"inputSchema",
+           {{"type", "object"},
+            {"properties",
+             {{"patch_id", {{"type", "string"}, {"description", "Patch ID containing the object"}}},
+              {"varname", {{"type", "string"}, {"description", "Object varname to query"}}},
+              {"side",
+               {{"type", "string"},
+                {"enum", json::array({"inlet", "outlet"})},
+                {"description", "Which edge to compute: 'inlet' (top) or 'outlet' (bottom)."}}}}},
+            {"required", json::array({"patch_id", "varname", "side"})}}}}});
 }
 
 // ============================================================================
@@ -296,6 +406,14 @@ json execute(const std::string& tool, const json& params) {
         return ToolCommon::test_mode_error();
 #else
         return execute_validate_layout(params);
+#endif
+    }
+
+    if (tool == "get_io_position") {
+#ifdef MAXMCP_TEST_MODE
+        return ToolCommon::test_mode_error();
+#else
+        return execute_get_io_position(params);
 #endif
     }
 

--- a/src/utils/io_geometry.cpp
+++ b/src/utils/io_geometry.cpp
@@ -1,0 +1,84 @@
+/**
+    @file io_geometry.cpp
+    MaxMCP - Inlet/outlet placement rule implementation
+
+    Pure reproduction of Max's nub placement (see io_geometry.h for the rule and
+    its calibration provenance). Max-API independent; the SDK glue that supplies
+    the rect, counts, and drawfirstin lives in src/tools/layout_tools.cpp.
+
+    @ingroup maxmcp
+*/
+
+#include "io_geometry.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace geometry {
+
+// Every object measured on Max 9 placed its nubs with a 9.5px inset on both the
+// two-or-more case (edge_inset) and the single-nub case (single_inset).
+namespace {
+constexpr IoCalibration kDefaultCalibration{/*edge_inset=*/9.5, /*single_inset=*/9.5};
+
+// Per-class overrides. Empty today — calibration found no class that diverges
+// from the default. Add a row here (and a fixture in test_io_geometry.cpp) if a
+// class or Max version is ever measured to differ.
+const std::unordered_map<std::string, IoCalibration>& class_calibration() {
+    static const std::unordered_map<std::string, IoCalibration> table{};
+    return table;
+}
+}  // namespace
+
+IoCalibration io_calibration_for(const std::string& maxclass) {
+    const auto& table = class_calibration();
+    auto it = table.find(maxclass);
+    return it != table.end() ? it->second : kDefaultCalibration;
+}
+
+std::vector<IoPosition> compute_io_positions(const Rect& rect, int visual_count, IoSide side,
+                                             const IoCalibration& cal) {
+    std::vector<IoPosition> positions;
+    if (visual_count <= 0) {
+        return positions;
+    }
+
+    const double y = (side == IoSide::Inlet) ? rect.origin.y : rect.bottom();
+
+    if (visual_count == 1) {
+        positions.push_back({0, {rect.origin.x + cal.single_inset, y}});
+        return positions;
+    }
+
+    // Two or more nubs: equally spaced between the left and right inset centers.
+    const double left_center = rect.origin.x + cal.edge_inset;
+    const double right_center = rect.right() - cal.edge_inset;
+    const double span = right_center - left_center;
+    positions.reserve(visual_count);
+    for (int i = 0; i < visual_count; ++i) {
+        const double x = left_center + span * i / (visual_count - 1);
+        positions.push_back({i, {x, y}});
+    }
+    return positions;
+}
+
+std::vector<IoPosition> io_positions(const Rect& rect, int logical_count, IoSide side,
+                                     bool draw_first_in, const std::string& maxclass) {
+    const IoCalibration cal = io_calibration_for(maxclass);
+
+    // Outlets always draw every nub; inlets draw every nub unless drawfirstin is
+    // false, in which case logical inlet 0 has no nub and the visible nubs map to
+    // logical indices 1..logical_count-1.
+    if (side == IoSide::Outlet || draw_first_in) {
+        return compute_io_positions(rect, logical_count, side, cal);
+    }
+
+    std::vector<IoPosition> positions = compute_io_positions(rect, logical_count - 1, side, cal);
+    for (IoPosition& p : positions) {
+        p.index += 1;  // shift 0..n-2 back onto logical indices 1..n-1
+    }
+    return positions;
+}
+
+}  // namespace geometry

--- a/src/utils/io_geometry.h
+++ b/src/utils/io_geometry.h
@@ -1,0 +1,122 @@
+/**
+    @file io_geometry.h
+    MaxMCP - Inlet/outlet pixel-position reproduction (Max-API independent)
+
+    Reproduces Max's inlet/outlet placement rule so callers can compute the pixel
+    center of any nub without a connected patchcord. The Max SDK exposes no public
+    getter for per-inlet/outlet coordinates, so this header encodes the rule and
+    its calibrated constants; the constants are pinned by fixture tests measured on
+    a real device (see tests/unit/test_io_geometry.cpp).
+
+    Placement rule (calibrated on Max 9, 2026-06-04, across newobj / number /
+    live.numbox / live.dial / gain~ / slider / live.gain~ / toggle):
+      - Inlets sit on the top edge (y = rect.y); outlets on the bottom edge
+        (y = rect.bottom()). This holds regardless of the box aspect ratio, so
+        tall objects need no special handling — the height is already in bottom().
+      - count == 1 : x = rect.x + single_inset
+      - count >= 2 : x_i = (rect.x + edge_inset)
+                           + (width - 2*edge_inset) * i / (count - 1)
+      - edge_inset == single_inset == 9.5 for every object measured; a single
+        global calibration is used. io_calibration_for() is the extension hook
+        for the rare class that ever diverges.
+      - Limitation: for pathologically narrow boxes (e.g. gain~ at width 22) Max
+        rounds a nub by up to ~0.5px from this rule; widening removes it.
+
+    Pure and Max-API independent (reuses geometry::Rect/Point only) so it is
+    unit-tested without the SDK and shared by the get_io_position glue.
+
+    @ingroup maxmcp
+*/
+
+#ifndef IO_GEOMETRY_H
+#define IO_GEOMETRY_H
+
+#include "utils/geometry.h"
+
+#include <string>
+#include <vector>
+
+namespace geometry {
+
+/**
+ * @brief Which edge of the box the nubs sit on.
+ */
+enum class IoSide { Inlet, Outlet };
+
+/**
+ * @brief Calibrated insets for one object class (or the global default).
+ *
+ * @c edge_inset is the distance from the box's left edge to the center of the
+ * leftmost nub (and symmetrically from the right edge to the rightmost nub) when
+ * there are two or more nubs. @c single_inset is the center offset used when
+ * there is exactly one nub. Both are 9.5 for every object measured to date.
+ */
+struct IoCalibration {
+    double edge_inset;
+    double single_inset;
+};
+
+/**
+ * @brief One computed nub: its logical index and pixel center.
+ *
+ * @c center reuses geometry::Point so callers share one coordinate vocabulary.
+ */
+struct IoPosition {
+    int index;
+    Point center;
+};
+
+/**
+ * @brief Calibration constants for a maxclass.
+ *
+ * Returns the per-class override when one is registered, otherwise the global
+ * default (9.5 / 9.5). Calibration showed no class needs an override yet; this
+ * lookup is the seam for adding one (or for a future Max version) without
+ * touching call sites.
+ *
+ * @param maxclass The object's maxclass (e.g. "cycle~", "live.dial")
+ * @return The calibration to use for that class
+ */
+IoCalibration io_calibration_for(const std::string& maxclass);
+
+/**
+ * @brief Compute nub centers from the placement rule (pure, no SDK).
+ *
+ * Applies the equal-spacing rule for @p visual_count nubs on the given side of
+ * @p rect using @p cal. Returned positions are indexed 0..visual_count-1. A
+ * @p visual_count <= 0 yields an empty vector.
+ *
+ * @param rect         The box's patching rectangle
+ * @param visual_count Number of drawn nubs on this side
+ * @param side         Inlet (top edge) or Outlet (bottom edge)
+ * @param cal          Calibration constants
+ * @return Nub centers, one per drawn nub, in index order
+ */
+std::vector<IoPosition> compute_io_positions(const Rect& rect, int visual_count, IoSide side,
+                                             const IoCalibration& cal);
+
+/**
+ * @brief Compute nub centers for an object, resolving calibration and the
+ *        drawfirstin correction.
+ *
+ * Convenience wrapper over compute_io_positions(): resolves calibration by
+ * @p maxclass and, for inlets whose first nub is not drawn (@p draw_first_in is
+ * false), computes @c logical_count-1 visible nubs and renumbers their @c index
+ * to the logical range 1..logical_count-1 (so indices stay aligned with the
+ * inlet numbers used by connect_max_objects). Outlets are unaffected by
+ * @p draw_first_in. The drawfirstin branch follows the documented rule but was
+ * not exercised by any measured object (all tested classes draw every inlet).
+ *
+ * @param rect          The box's patching rectangle
+ * @param logical_count The object's logical inlet/outlet count
+ * @param side          Inlet or Outlet
+ * @param draw_first_in Whether the first inlet is drawn (inlets only)
+ * @param maxclass      The object's maxclass, for calibration lookup
+ * @return Nub centers with logical indices
+ */
+std::vector<IoPosition> io_positions(const Rect& rect, int logical_count, IoSide side,
+                                     bool draw_first_in, const std::string& maxclass);
+
+}  // namespace geometry
+
+#endif  // IO_GEOMETRY_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SOURCES
     unit/test_console_logger.cpp
     unit/test_mcp_server.cpp
     unit/test_geometry.cpp
+    unit/test_io_geometry.cpp
     unit/test_layout_validate.cpp
 )
 
@@ -38,6 +39,7 @@ set(UTIL_SOURCES
     ../src/utils/patch_registry.cpp
     ../src/utils/patch_helpers.cpp
     ../src/utils/geometry.cpp
+    ../src/utils/io_geometry.cpp
     ../src/tools/layout_checks.cpp
 )
 
@@ -88,6 +90,7 @@ set(TOOL_SOURCES
     ../src/tools/layout_tools.cpp
     ../src/utils/patch_helpers.cpp
     ../src/utils/geometry.cpp
+    ../src/utils/io_geometry.cpp
     ../src/mcp_server.cpp
 )
 

--- a/tests/unit/test_io_geometry.cpp
+++ b/tests/unit/test_io_geometry.cpp
@@ -1,0 +1,239 @@
+/**
+    @file test_io_geometry.cpp
+    Unit tests for the inlet/outlet placement rule (src/utils/io_geometry.cpp).
+
+    Two layers:
+      1. Pure-rule tests of compute_io_positions / io_positions / io_calibration_for
+         with literal inputs (spacing, single-nub inset, inlet/outlet y, the
+         drawfirstin renumbering, empty edge cases).
+      2. Calibration fixtures: real cord-endpoint measurements taken on Max 9
+         (2026-06-04) via jpatchline_get_startpoint/endpoint. These pin the
+         calibrated constant (9.5) so a Max-version change that shifts a nub trips
+         a failure — the whole point of issue #76 is that this is verified, not
+         inferred. Measurement method: connect a cord to each nub, read its real
+         pixel center, after pinning and reading back the box's patching_rect.
+*/
+
+#include "utils/io_geometry.h"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using geometry::compute_io_positions;
+using geometry::io_calibration_for;
+using geometry::io_positions;
+using geometry::IoCalibration;
+using geometry::IoPosition;
+using geometry::IoSide;
+using geometry::Rect;
+
+namespace {
+
+// The calibrated default both insets share.
+constexpr double kInset = 9.5;
+
+// Assert a computed position list matches expected {index, x, y} triples within
+// tol. Exact fixtures use a tight tol; the narrow-box case loosens it (see note).
+void expect_positions(const std::vector<IoPosition>& actual,
+                      const std::vector<std::tuple<int, double, double>>& expected, double tol) {
+    ASSERT_EQ(actual.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(actual[i].index, std::get<0>(expected[i])) << "index mismatch at " << i;
+        EXPECT_NEAR(actual[i].center.x, std::get<1>(expected[i]), tol) << "x mismatch at " << i;
+        EXPECT_NEAR(actual[i].center.y, std::get<2>(expected[i]), tol) << "y mismatch at " << i;
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// io_calibration_for
+// ---------------------------------------------------------------------------
+
+TEST(IoCalibration, DefaultsTo95ForUnknownClass) {
+    IoCalibration cal = io_calibration_for("some.unmeasured.object");
+    EXPECT_DOUBLE_EQ(cal.edge_inset, 9.5);
+    EXPECT_DOUBLE_EQ(cal.single_inset, 9.5);
+}
+
+TEST(IoCalibration, NewobjUsesDefault) {
+    IoCalibration cal = io_calibration_for("cycle~");
+    EXPECT_DOUBLE_EQ(cal.edge_inset, 9.5);
+    EXPECT_DOUBLE_EQ(cal.single_inset, 9.5);
+}
+
+// ---------------------------------------------------------------------------
+// compute_io_positions — the pure rule
+// ---------------------------------------------------------------------------
+
+TEST(ComputeIoPositions, SingleNubUsesSingleInsetOnTopEdge) {
+    Rect rect{100.0, 50.0, 120.0, 22.0};
+    auto pos = compute_io_positions(rect, 1, IoSide::Inlet, {kInset, kInset});
+    expect_positions(pos, {{0, 109.5, 50.0}}, 1e-9);
+}
+
+TEST(ComputeIoPositions, SingleNubOutletUsesBottomEdge) {
+    Rect rect{100.0, 50.0, 120.0, 22.0};
+    auto pos = compute_io_positions(rect, 1, IoSide::Outlet, {kInset, kInset});
+    expect_positions(pos, {{0, 109.5, 72.0}}, 1e-9);  // y = 50 + 22
+}
+
+TEST(ComputeIoPositions, TwoNubsLandOnEdgeInsets) {
+    Rect rect{100.0, 50.0, 120.0, 22.0};
+    auto pos = compute_io_positions(rect, 2, IoSide::Inlet, {kInset, kInset});
+    // left = 100+9.5 = 109.5, right = 220-9.5 = 210.5
+    expect_positions(pos, {{0, 109.5, 50.0}, {1, 210.5, 50.0}}, 1e-9);
+}
+
+TEST(ComputeIoPositions, FourNubsAreEquallySpaced) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    auto pos = compute_io_positions(rect, 4, IoSide::Inlet, {kInset, kInset});
+    // step = (120-19)/3 = 33.6667
+    expect_positions(pos,
+                     {{0, 309.5, 200.0},
+                      {1, 343.16666666666667, 200.0},
+                      {2, 376.83333333333333, 200.0},
+                      {3, 410.5, 200.0}},
+                     1e-9);
+}
+
+TEST(ComputeIoPositions, NonPositiveCountIsEmpty) {
+    Rect rect{0.0, 0.0, 100.0, 20.0};
+    EXPECT_TRUE(compute_io_positions(rect, 0, IoSide::Inlet, {kInset, kInset}).empty());
+    EXPECT_TRUE(compute_io_positions(rect, -1, IoSide::Outlet, {kInset, kInset}).empty());
+}
+
+// ---------------------------------------------------------------------------
+// io_positions — calibration resolution + drawfirstin correction
+// ---------------------------------------------------------------------------
+
+TEST(IoPositions, DrawnInletsKeepLogicalIndices) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    auto pos = io_positions(rect, 2, IoSide::Inlet, /*draw_first_in=*/true, "cycle~");
+    expect_positions(pos, {{0, 309.5, 200.0}, {1, 410.5, 200.0}}, 1e-9);
+}
+
+TEST(IoPositions, UndrawnFirstInletDropsNubAndRenumbers) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    // 3 logical inlets, first not drawn -> 2 visible nubs at logical indices 1,2.
+    auto pos = io_positions(rect, 3, IoSide::Inlet, /*draw_first_in=*/false, "fake.class");
+    // 2 nubs spaced across the edge insets, indices shifted to 1,2.
+    expect_positions(pos, {{1, 309.5, 200.0}, {2, 410.5, 200.0}}, 1e-9);
+}
+
+TEST(IoPositions, UndrawnFirstInletWithSingleLogicalInletIsEmpty) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    EXPECT_TRUE(
+        io_positions(rect, 1, IoSide::Inlet, /*draw_first_in=*/false, "fake.class").empty());
+}
+
+TEST(IoPositions, OutletsIgnoreDrawFirstIn) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    auto with = io_positions(rect, 2, IoSide::Outlet, /*draw_first_in=*/true, "number");
+    auto without = io_positions(rect, 2, IoSide::Outlet, /*draw_first_in=*/false, "number");
+    ASSERT_EQ(with.size(), without.size());
+    for (size_t i = 0; i < with.size(); ++i) {
+        EXPECT_EQ(with[i].index, without[i].index);
+        EXPECT_DOUBLE_EQ(with[i].center.x, without[i].center.x);
+        EXPECT_DOUBLE_EQ(with[i].center.y, without[i].center.y);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Calibration fixtures — measured on Max 9 (2026-06-04)
+//
+// Each case pins io_positions() against real cord-endpoint centers. Rects are the
+// values read back from Max after pinning (UI objects clamp their height). Tol is
+// tight (0.01) for every class except the deliberately narrow gain~, which Max
+// rounds by ~0.5px (documented limitation).
+// ---------------------------------------------------------------------------
+
+TEST(IoCalibrationFixtures, CycleNewobj) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    expect_positions(io_positions(rect, 2, IoSide::Inlet, true, "cycle~"),
+                     {{0, 309.5, 200.0}, {1, 410.5, 200.0}}, 0.01);
+    expect_positions(io_positions(rect, 1, IoSide::Outlet, true, "cycle~"), {{0, 309.5, 222.0}},
+                     0.01);
+}
+
+TEST(IoCalibrationFixtures, PakFourInlets) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    expect_positions(io_positions(rect, 4, IoSide::Inlet, true, "pak"),
+                     {{0, 309.5, 200.0},
+                      {1, 343.16666666666667, 200.0},
+                      {2, 376.83333333333333, 200.0},
+                      {3, 410.5, 200.0}},
+                     0.01);
+}
+
+TEST(IoCalibrationFixtures, NumberBoxTwoOutlets) {
+    Rect rect{300.0, 200.0, 120.0, 22.0};
+    expect_positions(io_positions(rect, 1, IoSide::Inlet, true, "number"), {{0, 309.5, 200.0}},
+                     0.01);
+    expect_positions(io_positions(rect, 2, IoSide::Outlet, true, "number"),
+                     {{0, 309.5, 222.0}, {1, 410.5, 222.0}}, 0.01);
+}
+
+TEST(IoCalibrationFixtures, LiveNumbox) {
+    Rect rect{300.0, 200.0, 120.0, 15.0};  // height clamped to 15
+    expect_positions(io_positions(rect, 1, IoSide::Inlet, true, "live.numbox"), {{0, 309.5, 200.0}},
+                     0.01);
+    expect_positions(io_positions(rect, 2, IoSide::Outlet, true, "live.numbox"),
+                     {{0, 309.5, 215.0}, {1, 410.5, 215.0}}, 0.01);
+}
+
+TEST(IoCalibrationFixtures, LiveDial) {
+    Rect rect{300.0, 200.0, 120.0, 48.0};  // height clamped to 48
+    expect_positions(io_positions(rect, 1, IoSide::Inlet, true, "live.dial"), {{0, 309.5, 200.0}},
+                     0.01);
+    expect_positions(io_positions(rect, 2, IoSide::Outlet, true, "live.dial"),
+                     {{0, 309.5, 248.0}, {1, 410.5, 248.0}}, 0.01);
+}
+
+TEST(IoCalibrationFixtures, GainTallWide) {
+    Rect rect{300.0, 180.0, 120.0, 140.0};  // tall object, normal width
+    expect_positions(io_positions(rect, 1, IoSide::Inlet, true, "gain~"), {{0, 309.5, 180.0}},
+                     0.01);
+    expect_positions(io_positions(rect, 2, IoSide::Outlet, true, "gain~"),
+                     {{0, 309.5, 320.0}, {1, 410.5, 320.0}}, 0.01);
+}
+
+TEST(IoCalibrationFixtures, GainNarrowRoundingLimitation) {
+    // gain~ at its native narrow width (22px). Max rounds the right outlet to
+    // 313.0 where the rule predicts 312.5 — a sub-pixel deviation that only
+    // appears on pathologically narrow boxes. Documented limitation; loose tol.
+    Rect rect{300.0, 180.0, 22.0, 140.0};
+    expect_positions(io_positions(rect, 2, IoSide::Outlet, true, "gain~"),
+                     {{0, 309.5, 320.0}, {1, 313.0, 320.0}}, 0.6);
+}
+
+TEST(IoCalibrationFixtures, SliderTallNarrowSingleNub) {
+    Rect rect{300.0, 160.0, 20.0, 140.0};
+    expect_positions(io_positions(rect, 1, IoSide::Inlet, true, "slider"), {{0, 309.5, 160.0}},
+                     0.01);
+    expect_positions(io_positions(rect, 1, IoSide::Outlet, true, "slider"), {{0, 309.5, 300.0}},
+                     0.01);
+}
+
+TEST(IoCalibrationFixtures, LiveGainFiveOutlets) {
+    Rect rect{300.0, 160.0, 48.0, 136.0};  // tall Live UI, 2 inlets / 5 outlets
+    expect_positions(io_positions(rect, 2, IoSide::Inlet, true, "live.gain~"),
+                     {{0, 309.5, 160.0}, {1, 338.5, 160.0}}, 0.01);
+    expect_positions(io_positions(rect, 5, IoSide::Outlet, true, "live.gain~"),
+                     {{0, 309.5, 296.0},
+                      {1, 316.75, 296.0},
+                      {2, 324.0, 296.0},
+                      {3, 331.25, 296.0},
+                      {4, 338.5, 296.0}},
+                     0.01);
+}
+
+TEST(IoCalibrationFixtures, ToggleSquareSingleNub) {
+    Rect rect{300.0, 200.0, 24.0, 24.0};
+    expect_positions(io_positions(rect, 1, IoSide::Inlet, true, "toggle"), {{0, 309.5, 200.0}},
+                     0.01);
+    expect_positions(io_positions(rect, 1, IoSide::Outlet, true, "toggle"), {{0, 309.5, 224.0}},
+                     0.01);
+}

--- a/tests/unit/test_tool_routing.cpp
+++ b/tests/unit/test_tool_routing.cpp
@@ -238,7 +238,7 @@ TEST_F(MCPServerRoutingTest, ToolsListReturnsAllTools) {
 
     auto& tools = response["result"]["tools"];
     ASSERT_TRUE(tools.is_array());
-    EXPECT_EQ(tools.size(), 27) << "tools/list should return all 27 tools";
+    EXPECT_EQ(tools.size(), 28) << "tools/list should return all 28 tools";
 }
 
 TEST_F(MCPServerRoutingTest, ToolsListResponseFormat) {


### PR DESCRIPTION
## 概要

Issue #76 の Step 3。オブジェクトの inlet（上辺）/ outlet（下辺）の**ピクセル中心 (x, y)** を返す新 MCP ツール `get_io_position` を追加。Max SDK には inlet/outlet 座標を返す getter が無いため、**Max の等間隔配置ルールをサーバ側で再現**し、定数を**実機のコード端点で校正**してユニットテストで固定する。これで LLM が幅合わせで使っていた近似式 `left + 9.5 + (w-19)*i/(n-1)` の手計算を撲滅する。ツール総数 27 → 28。

## 実装

| 領域 | 内容 |
|---|---|
| `src/utils/io_geometry.{h,cpp}`（新・純粋） | `compute_io_positions`（配置則）/ `io_positions`（校正解決 + drawfirstin 補正）/ `io_calibration_for`（グローバル 9.5 + per-class 上書きフック）。namespace `geometry`、`geometry::Rect/Point` を再利用、Max 非依存 |
| `src/tools/layout_tools.cpp` | `get_io_position` の defer グルー・スキーマ・dispatch。戻り規約は `get_object_io_info` に踏襲 |
| `tests/unit/test_io_geometry.cpp`（新） | 純粋ルール / drawfirstin / **実測校正フィクスチャ**（Max 9）。`maxmcp_tests` と `test_tool_routing` 両ターゲットへリンク |
| 配線 | ルート `CMakeLists.txt`（UTILS_SRC）、`tests/CMakeLists.txt`、ルーティング集約数 27→28、`mcp_server.cpp` コメント |
| ドキュメント | mcp-tools-reference / INDEX / integration-test-checklist(#28) / layout-validation-tools-spec / CLAUDE / layout-rules（近似式を get_io_position に置換）|

## 校正結果（Max 9, 実機測定）

代表 8 種（newobj `cycle~`/`pak`, `number`, `live.numbox`, `live.dial`, `gain~`, `slider`, `live.gain~`, `toggle`）をコード端点で実測:

- **`edge_inset = single_inset = 9.5` が全種で普遍** → per-class テーブル不要（拡張フックのみ保持）
- **inlet y = `rect.y` / outlet y = `rect.bottom()`** も普遍 → **縦長オブジェクトの特別扱い不要**（高さは下辺に織り込まれる）
- 唯一の例外: 幅が極端に狭い時（gain~ 幅22px）に nub が ≤0.5px 丸められる（幅依存・縦長無関係、フィクスチャに記録）

## 設計判断

`validate_layout` とは**統合しない**。`validate_layout` は既存コードの実端点（`jpatchline_get_startpoint/endpoint` ＝グラウンドトゥルース）を使い近似式より正確。`get_io_position` の式は「未接続 nub の座標算出」用のフォールバックで、両者は `geometry::Rect/Point` を共通語彙として整合する。

## 検証

- `./build.sh --test`: **189 テスト 100% pass**（IoGeometry/IoCalibration/IoPositions 群・ルーティング集約数含む）
- `pr-review-toolkit:code-reviewer` 通過（信頼度80以上の問題なし）
- **実機統合テスト**: デプロイ後、全 28 ツールのチェックリストを Max 9 で完走・全合格。特に **#28b クロスチェックで get_io_position の出力が `get_patchlines` の実コード端点とピクセル単位で一致**（inlet/outlet・縦長 slider・エラー系含む）

Refs #76（Step 3。Step 4 `suggest_alignment` 以降は別 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)