### PR TITLE
feat(tools): add suggest_alignment MCP tool (Issue #76 Step 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ npm run format:check
 - **`src/utils/`**: Shared utilities (UUID generator, console logger, patch registry, patch helpers)
 - *Note*: Legacy files `maxmcp_server.cpp`, `udp_server.cpp` from the earlier separate-external architecture have been removed
 
-### MCP Tools (28 total)
+### MCP Tools (29 total)
 
 Full tool reference with parameters and response formats: [docs/mcp-tools-reference.md](docs/mcp-tools-reference.md)
 
@@ -106,7 +106,7 @@ Full tool reference with parameters and response formats: [docs/mcp-tools-refere
 | Patch State | 3 | `get_patch_lock_state`, `set_patch_lock_state`, `get_patch_dirty` |
 | Hierarchy | 2 | `get_parent_patcher`, `get_subpatchers` |
 | Utilities | 2 | `get_console_log`, `get_avoid_rect_position` |
-| Layout Validation | 2 | `validate_layout`, `get_io_position` |
+| Layout Validation | 3 | `validate_layout`, `get_io_position`, `suggest_alignment` |
 
 ### Threading Model
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(UTILS_SRC
     src/utils/patch_registry.h
     src/utils/patch_helpers.cpp
     src/utils/patch_helpers.h
+    src/utils/format_util.h
     src/utils/geometry.cpp
     src/utils/geometry.h
     src/utils/io_geometry.cpp

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,7 +1,7 @@
 # MaxMCP Documentation Index
 
 **Last Updated**: 2026-06-04
-**Project Status**: 28 MCP Tools
+**Project Status**: 29 MCP Tools
 
 ---
 
@@ -73,7 +73,7 @@ This index provides a comprehensive overview of all MaxMCP documentation.
 **Purpose**: Complete reference for all MCP tools
 **Audience**: Developers, users
 **Contents**:
-- All 28 MCP tools documentation
+- All 29 MCP tools documentation
 - Parameter specifications
 - Response formats
 - Error codes

--- a/docs/integration-test-checklist.md
+++ b/docs/integration-test-checklist.md
@@ -1,6 +1,6 @@
 # MCP Integration Test Checklist
 
-**Total Tools**: 28
+**Total Tools**: 29
 **Purpose**: Manual verification checklist for all MCP tools. Use before PR merges and releases.
 
 ---
@@ -78,7 +78,7 @@
 | 26c | `get_avoid_rect_position` | `width`/`height` of a large object    | Returned spot clears all objects by the gap for that size; rationale notes the size | [ ]  |
 | 26d | `get_avoid_rect_position` | Negative `near_x`/`near_y`            | Result clamped to non-negative coordinates (x ≥ 0, y ≥ 0)           | [ ]  |
 
-## Layout Validation (2)
+## Layout Validation (3)
 
 `validate_layout` is read-only. For each case, set up the patch state described, then run the tool and confirm the finding (or `clean`).
 
@@ -106,6 +106,16 @@
 | 28c | `get_io_position` | Tall object (`gain~`, `slider`)                                       | inlet y = top, outlet y = bottom (height handled); x uses the calibrated inset             | [ ]  |
 | 28d | `get_io_position` | Unknown `varname`                                                    | Error: "Object not found: <varname>"                                                        | [ ]  |
 | 28e | `get_io_position` | Invalid `side` (not inlet/outlet)                                    | Error: side must be "inlet" or "outlet"                                                      | [ ]  |
+
+`suggest_alignment` is read-only (returns a recommended rect; apply it with `set_object_attribute`). Verify by applying the rect, then `get_io_position` on both nubs to confirm they share x.
+
+| #   | Tool                | Test                                                                        | Expected                                                                                       | Pass |
+|-----|---------------------|-----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|------|
+| 29  | `suggest_alignment` | `adjust:"width"`: size a multi-outlet object so an outlet lands on an inlet  | `recommended_patching_rect` returned; after applying, `get_io_position` outlet x == anchor x   | [ ]  |
+| 29a | `suggest_alignment` | `adjust:"left"`: move a target so its inlet lands under an anchor outlet     | left changes, width unchanged; after applying, the two nubs share x                             | [ ]  |
+| 29b | `suggest_alignment` | `adjust:"width"` targeting the leftmost nub (index 0)                        | Error suggesting `adjust:"left"` (leftmost nub is width-independent)                            | [ ]  |
+| 29c | `suggest_alignment` | `adjust:"width"` on a single-nub side                                       | Error suggesting `adjust:"left"`                                                                | [ ]  |
+| 29d | `suggest_alignment` | Unknown `varname` (anchor or target), or bad `side`/`adjust`                | Appropriate error; patch is never modified                                                       | [ ]  |
 
 ---
 

--- a/docs/layout-validation-tools-spec.md
+++ b/docs/layout-validation-tools-spec.md
@@ -2,7 +2,7 @@
 
 **作成日**: 2026-06-03
 **対象読者**: MaxMCP を開発する Claude / 開発者
-**ステータス**: 実装中（Section 7 の Step 1 `geometry.{h,cpp}`、Step 2 `validate_layout`、Step 3 `get_io_position` は実装済み。Step 4 `suggest_alignment` 以降は未着手）
+**ステータス**: 実装中（Section 7 の Step 1 `geometry.{h,cpp}`、Step 2 `validate_layout`、Step 3 `get_io_position`、Step 4 `suggest_alignment` は実装済み。`align_objects`（Step 4 併記）と Step 5 `render_patch_preview` 以降は未着手）
 
 ---
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -8,7 +8,7 @@ This document provides a complete reference for all MCP tools available in MaxMC
 
 ## Overview
 
-MaxMCP provides 28 MCP tools for controlling Max/MSP patches through natural language commands. Tools are organized into categories based on their functionality.
+MaxMCP provides 29 MCP tools for controlling Max/MSP patches through natural language commands. Tools are organized into categories based on their functionality.
 
 ---
 
@@ -22,7 +22,7 @@ MaxMCP provides 28 MCP tools for controlling Max/MSP patches through natural lan
 | Patch State | 3 | Lock state and dirty flag management |
 | Hierarchy | 2 | Parent/child patcher navigation |
 | Utilities | 2 | Console logging and positioning |
-| Layout Validation | 2 | Machine-check layout geometry, compute inlet/outlet positions |
+| Layout Validation | 3 | Machine-check layout geometry, compute inlet/outlet positions, suggest alignment |
 
 ---
 
@@ -872,6 +872,48 @@ object so a given inlet lands at a target x.
 - Inlets report `y = patching_rect.y`; outlets report `y = patching_rect.y + height`. This holds for tall objects (the height is already in the bottom edge).
 - The placement rule is exact for normal widths; for pathologically narrow objects (e.g. `gain~` at its native 22px width) Max rounds a nub by up to ~0.5px.
 - If the object's first inlet is not drawn (`jbox_get_drawfirstin` is false), that nub is omitted and the remaining inlets keep their logical indices (1..n-1).
+
+---
+
+### `suggest_alignment`
+
+Compute the `patching_rect` that makes a target object's chosen inlet/outlet
+share the **anchor** nub's x — i.e. so a patchcord between them is a vertical
+straight line. **Read-only**: it returns a recommendation; apply it yourself with
+`set_object_attribute patching_rect`. The geometry uses the same calibrated rule
+as `get_io_position`, so no hand-computed inset math is needed.
+
+`adjust` chooses what changes:
+- `"width"` — resize the target (keep its left edge). Used to size a multi-outlet object so an outlet lands over a destination inlet.
+- `"left"` — move the target horizontally (keep its width).
+
+**Parameters**:
+```json
+{
+  "patch_id": {"type": "string", "required": true, "description": "Patch ID containing the objects"},
+  "anchor": {"type": "object", "required": true, "description": "{varname, side: inlet|outlet, index} — the reference nub"},
+  "target": {"type": "object", "required": true, "description": "{varname, side: inlet|outlet, index} — the object to reposition/resize"},
+  "adjust": {"type": "string", "required": true, "description": "'width' (resize, keep left) or 'left' (move, keep width)"}
+}
+```
+
+**Response**:
+```json
+{
+  "result": {
+    "anchor": {"varname": "curve_n", "side": "outlet", "index": 0, "x": 669.5},
+    "target": {"varname": "curve_scale", "side": "inlet", "index": 5},
+    "adjust": "width",
+    "recommended_patching_rect": [453.0, 1180.0, 226.0, 20.0],
+    "rationale": "inlet5 x must equal 669.5; with left=453.0 -> width=226.0"
+  }
+}
+```
+
+**Notes**:
+- Indices are logical (match `connect_max_objects` / `get_io_position`).
+- `adjust: "width"` cannot move the **leftmost** nub (index 0 of the visible nubs) or a **single-nub** side — those are independent of width; the tool returns an error suggesting `adjust: "left"`.
+- An anchor too far left for the chosen nub to reach by widening yields a non-positive width and is rejected (nothing is applied — the tool never mutates the patch).
 
 ---
 

--- a/plugins/maxmcp/skills/patch-guidelines/reference/layout-rules.md
+++ b/plugins/maxmcp/skills/patch-guidelines/reference/layout-rules.md
@@ -470,8 +470,8 @@ size the source so its outlets line up over the destination inlets. **Do not
 hand-compute this with a `±9.5` inset formula** — the inset is calibrated and the
 spacing depends on the outlet count. Instead:
 
-1. Call **`get_io_position`** on each destination (`side:"inlet"`) to get the exact target X of each inlet.
-2. Call **`get_io_position`** on the source (`side:"outlet"`) and adjust the source's `patching_rect` width until the outlet X values land on those targets (re-query after resizing).
+- **Best**: call **`suggest_alignment`** with `adjust:"width"`, the source outlet as `target` and a destination inlet as `anchor`. It returns the exact `recommended_patching_rect` (the inverse is solved server-side); apply it with `set_object_attribute`. Use `adjust:"left"` to instead move an object so its single/leftmost nub lands on an anchor.
+- **Manual cross-check**: `get_io_position` gives each nub's exact x if you want to verify the result.
 
 This replaces the old approximation `width = (rightmost_dest_x + 9.5) - source_x + 9.5`, which ignored per-object inset differences.
 

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -93,7 +93,7 @@ void MCPServer::stop() {
  * - StateTools (3 tools)
  * - HierarchyTools (2 tools)
  * - UtilityTools (2 tools)
- * - LayoutTools (2 tools)
+ * - LayoutTools (3 tools)
  *
  * @return JSON array of all tool schemas
  */

--- a/src/tools/layout_checks.cpp
+++ b/src/tools/layout_checks.cpp
@@ -12,11 +12,10 @@
 
 #include "layout_checks.h"
 
+#include "utils/format_util.h"
 #include "utils/geometry.h"
 
 #include <algorithm>
-#include <cmath>
-#include <cstdio>
 #include <set>
 #include <string>
 #include <utility>
@@ -24,24 +23,14 @@
 
 namespace LayoutTools {
 
+using fmtutil::fmt1;
+using fmtutil::fmti;
+
 // ============================================================================
 // Formatting helpers
 // ============================================================================
 
 namespace {
-
-// One-decimal coordinate, e.g. "876.8" — matches the precision used in spec
-// findings without dumping the full double precision.
-std::string fmt1(double v) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "%.1f", v);
-    return buf;
-}
-
-// Rounded integer string, for areas and overlap-region bounds.
-std::string fmti(double v) {
-    return std::to_string(static_cast<long>(std::llround(v)));
-}
 
 // A human-readable label for an object: its varname, or maxclass#id when unnamed.
 std::string label_for(const LayoutObject& o) {

--- a/src/tools/layout_tools.cpp
+++ b/src/tools/layout_tools.cpp
@@ -55,6 +55,21 @@ struct t_get_io_position_data {
     DeferredResult* deferred_result;
 };
 
+// One end of an alignment request: an object's inlet/outlet at a logical index.
+struct AlignEndpoint {
+    std::string varname;
+    geometry::IoSide side;
+    int index;
+};
+
+struct t_suggest_alignment_data {
+    t_maxmcp* patch;
+    AlignEndpoint anchor;
+    AlignEndpoint target;
+    geometry::AlignAdjust adjust;
+    DeferredResult* deferred_result;
+};
+
 // ============================================================================
 // Production Code (Max SDK required)
 // ============================================================================
@@ -337,64 +352,291 @@ static json execute_get_io_position(const json& params) {
     return {{"result", result}};
 }
 
+// Resolve one alignment endpoint to the pixel x of its nub. On failure, writes a
+// message and returns false. @p x_out is the nub's x; @p box_out is the resolved
+// box (the caller needs the target box's rect/counts for the inverse solve).
+static bool resolve_endpoint_x(t_object* patcher, const AlignEndpoint& ep, double& x_out,
+                               t_object*& box_out, std::string& err_out) {
+    t_object* box = PatchHelpers::find_box_by_varname(patcher, ep.varname);
+    if (!box) {
+        err_out = "Object not found: " + ep.varname;
+        return false;
+    }
+    box_out = box;
+
+    t_rect rect;
+    jbox_get_patching_rect(box, &rect);
+    const geometry::Rect box_rect{rect.x, rect.y, rect.width, rect.height};
+    const bool is_inlet = (ep.side == geometry::IoSide::Inlet);
+    const long count =
+        is_inlet ? PatchHelpers::get_inlet_count(box) : PatchHelpers::get_outlet_count(box);
+    const bool draw_first_in = is_inlet ? (jbox_get_drawfirstin(box) != 0) : true;
+    const std::string maxclass = PatchHelpers::get_box_maxclass(box);
+
+    for (const geometry::IoPosition& p : geometry::io_positions(box_rect, static_cast<int>(count),
+                                                                ep.side, draw_first_in, maxclass)) {
+        if (p.index == ep.index) {
+            x_out = p.center.x;
+            return true;
+        }
+    }
+    err_out = ep.varname + " has no drawn " + (is_inlet ? "inlet " : "outlet ") +
+              std::to_string(ep.index);
+    return false;
+}
+
+/**
+ * Deferred callback for suggest_alignment.
+ * Computes the anchor nub's x, then solves the target's rect (via the pure
+ * inverse in io_geometry.h) so its chosen nub lands on that x. Read-only.
+ */
+static void suggest_alignment_deferred(t_maxmcp* patch, t_symbol* s, long argc, t_atom* argv) {
+    VALIDATE_DEFERRED_ARGS("suggest_alignment_deferred");
+    EXTRACT_DEFERRED_DATA_WITH_RESULT(t_suggest_alignment_data, data, argv);
+
+    t_object* patcher = data->patch->patcher;
+
+    double anchor_x = 0.0;
+    t_object* anchor_box = nullptr;
+    std::string err;
+    if (!resolve_endpoint_x(patcher, data->anchor, anchor_x, anchor_box, err)) {
+        COMPLETE_DEFERRED(data, ToolCommon::make_error(ToolCommon::ErrorCode::INVALID_PARAMS, err));
+        return;
+    }
+
+    t_object* target_box = PatchHelpers::find_box_by_varname(patcher, data->target.varname);
+    if (!target_box) {
+        COMPLETE_DEFERRED(data, ToolCommon::object_not_found_error(data->target.varname));
+        return;
+    }
+
+    t_rect rect;
+    jbox_get_patching_rect(target_box, &rect);
+    const geometry::Rect target_rect{rect.x, rect.y, rect.width, rect.height};
+    const bool target_is_inlet = (data->target.side == geometry::IoSide::Inlet);
+    const long target_count = target_is_inlet ? PatchHelpers::get_inlet_count(target_box)
+                                              : PatchHelpers::get_outlet_count(target_box);
+    const bool target_draw_first_in =
+        target_is_inlet ? (jbox_get_drawfirstin(target_box) != 0) : true;
+    const std::string target_maxclass = PatchHelpers::get_box_maxclass(target_box);
+
+    const geometry::AlignmentResult rec = geometry::recommend_alignment_rect(
+        target_rect, static_cast<int>(target_count), data->target.side, data->target.index,
+        target_draw_first_in, target_maxclass, anchor_x, data->adjust);
+    if (!rec.ok) {
+        COMPLETE_DEFERRED(
+            data, ToolCommon::make_error(ToolCommon::ErrorCode::INVALID_PARAMS, rec.reason));
+        return;
+    }
+
+    json out = {{"anchor",
+                 {{"varname", data->anchor.varname},
+                  {"side", data->anchor.side == geometry::IoSide::Inlet ? "inlet" : "outlet"},
+                  {"index", data->anchor.index},
+                  {"x", anchor_x}}},
+                {"target",
+                 {{"varname", data->target.varname},
+                  {"side", target_is_inlet ? "inlet" : "outlet"},
+                  {"index", data->target.index}}},
+                {"adjust", data->adjust == geometry::AlignAdjust::Width ? "width" : "left"},
+                {"recommended_patching_rect", json::array({rec.rect.origin.x, rec.rect.origin.y,
+                                                           rec.rect.width, rec.rect.height})},
+                {"rationale", rec.reason}};
+    COMPLETE_DEFERRED(data, out);
+}
+
+// Parse an {varname, side, index} endpoint object. Returns false with an error
+// message when a field is missing or invalid.
+static bool parse_endpoint(const json& obj, const char* role, AlignEndpoint& ep,
+                           std::string& err_out) {
+    if (!obj.is_object()) {
+        err_out = std::string(role) + " must be an object with varname, side, index";
+        return false;
+    }
+    ep.varname = obj.value("varname", "");
+    const std::string side_str = obj.value("side", "");
+    if (ep.varname.empty() || side_str.empty() || !obj.contains("index")) {
+        err_out = std::string(role) + " requires varname, side, and index";
+        return false;
+    }
+    if (side_str != "inlet" && side_str != "outlet") {
+        err_out = std::string(role) + " side must be \"inlet\" or \"outlet\"";
+        return false;
+    }
+    if (!obj["index"].is_number_integer()) {
+        err_out = std::string(role) + " index must be an integer";
+        return false;
+    }
+    ep.side = (side_str == "inlet") ? geometry::IoSide::Inlet : geometry::IoSide::Outlet;
+    ep.index = obj["index"].get<int>();
+    return true;
+}
+
+/**
+ * Execute suggest_alignment tool.
+ */
+static json execute_suggest_alignment(const json& params) {
+    std::string patch_id = params.value("patch_id", "");
+    std::string adjust_str = params.value("adjust", "");
+    if (patch_id.empty() || adjust_str.empty()) {
+        return ToolCommon::make_error(ToolCommon::ErrorCode::INVALID_PARAMS,
+                                      "Missing required parameters: patch_id and adjust");
+    }
+    if (adjust_str != "width" && adjust_str != "left") {
+        return ToolCommon::make_error(ToolCommon::ErrorCode::INVALID_PARAMS,
+                                      "adjust must be \"width\" or \"left\"");
+    }
+
+    AlignEndpoint anchor, target;
+    std::string err;
+    if (!parse_endpoint(params.value("anchor", json::object()), "anchor", anchor, err) ||
+        !parse_endpoint(params.value("target", json::object()), "target", target, err)) {
+        return ToolCommon::make_error(ToolCommon::ErrorCode::INVALID_PARAMS, err);
+    }
+
+    t_maxmcp* patch = PatchRegistry::find_patch(patch_id);
+    if (!patch) {
+        return ToolCommon::patch_not_found_error(patch_id);
+    }
+
+    const geometry::AlignAdjust adjust =
+        (adjust_str == "width") ? geometry::AlignAdjust::Width : geometry::AlignAdjust::Left;
+
+    auto* deferred_result = new DeferredResult();
+    auto* data = new t_suggest_alignment_data{patch, anchor, target, adjust, deferred_result};
+
+    t_atom a;
+    atom_setobj(&a, data);
+    defer(patch, (method)suggest_alignment_deferred, gensym("suggest_alignment"), 1, &a);
+
+    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
+        delete deferred_result;
+        return ToolCommon::timeout_error("suggesting alignment");
+    }
+
+    json result = deferred_result->result;
+    delete deferred_result;
+
+    if (result.contains("error")) {
+        return result;
+    }
+    return {{"result", result}};
+}
+
 #endif  // MAXMCP_TEST_MODE
 
 // ============================================================================
 // Tool Schemas
 // ============================================================================
 
+// clang-format off
+// The JSON tool schemas are hand-indented to mirror their structure; clang-format
+// would reflow the nested initializer lists into an unreadable shape.
 json get_tool_schemas() {
-    return json::array(
-        {{{"name", "validate_layout"},
-          {"description",
-           "Machine-check a patch's layout geometry (read-only) and return a structured "
-           "findings list. Replaces the manual Phase 8 checks of organize-patch: object "
-           "overlaps, upward patchcords, patchcords crossing unrelated objects, and "
-           "collinear overlapping cords. Call this before saving and fix findings until "
-           "'clean' is true."},
-          {"inputSchema",
-           {{"type", "object"},
-            {"properties",
-             {{"patch_id", {{"type", "string"}, {"description", "Patch ID to validate"}}},
-              {"scope_varnames",
-               {{"type", "array"},
-                {"items", {{"type", "string"}}},
-                {"description", "Optional. Limit checks to these objects (and cords between "
-                                "them). Omit to check the whole patch."}}},
-              {"mode",
-               {{"type", "string"},
-                {"enum", json::array({"patching", "presentation"})},
-                {"description", "Coordinate space to check. Default 'patching'. 'presentation' "
-                                "checks presentation_rect overlaps of objects shown in "
-                                "presentation (cord checks are skipped)."}}},
-              {"checks",
-               {{"type", "array"},
-                {"items",
-                 {{"type", "string"},
-                  {"enum", json::array({"upward", "overlap", "cord_object", "cord_cord",
-                                        "presentation_overlap"})}}},
-                {"description", "Optional subset of checks to run. Omit to run all."}}},
-              {"epsilon",
-               {{"type", "number"},
-                {"description", "Tolerance in pixels for all checks (default: 2.0)."}}}}},
-            {"required", json::array({"patch_id"})}}}},
-         {{"name", "get_io_position"},
-          {"description",
-           "Return the pixel center (x, y) of each inlet (top edge) or outlet (bottom edge) "
-           "of an object, computed with Max's calibrated equal-spacing rule. Use instead of "
-           "hand-computing nub x positions for width/alignment work. 'index' is the logical "
-           "inlet/outlet number (matches connect_max_objects)."},
-          {"inputSchema",
-           {{"type", "object"},
-            {"properties",
-             {{"patch_id", {{"type", "string"}, {"description", "Patch ID containing the object"}}},
-              {"varname", {{"type", "string"}, {"description", "Object varname to query"}}},
-              {"side",
-               {{"type", "string"},
-                {"enum", json::array({"inlet", "outlet"})},
-                {"description", "Which edge to compute: 'inlet' (top) or 'outlet' (bottom)."}}}}},
-            {"required", json::array({"patch_id", "varname", "side"})}}}}});
+    const json endpoint_props = {
+        {"varname", {{"type", "string"}, {"description", "Object varname"}}},
+        {"side",    {{"type", "string"}, {"enum", json::array({"inlet", "outlet"})}}},
+        {"index",   {{"type", "integer"}, {"description", "Logical inlet/outlet index"}}},
+    };
+
+    return json::array({
+        {
+            {"name", "validate_layout"},
+            {"description",
+             "Machine-check a patch's layout geometry (read-only) and return a structured "
+             "findings list. Replaces the manual Phase 8 checks of organize-patch: object "
+             "overlaps, upward patchcords, patchcords crossing unrelated objects, and "
+             "collinear overlapping cords. Call this before saving and fix findings until "
+             "'clean' is true."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"properties", {
+                    {"patch_id", {{"type", "string"}, {"description", "Patch ID to validate"}}},
+                    {"scope_varnames", {
+                        {"type", "array"},
+                        {"items", {{"type", "string"}}},
+                        {"description", "Optional. Limit checks to these objects (and cords "
+                                        "between them). Omit to check the whole patch."}}},
+                    {"mode", {
+                        {"type", "string"},
+                        {"enum", json::array({"patching", "presentation"})},
+                        {"description", "Coordinate space to check. Default 'patching'. "
+                                        "'presentation' checks presentation_rect overlaps of "
+                                        "objects shown in presentation (cord checks are "
+                                        "skipped)."}}},
+                    {"checks", {
+                        {"type", "array"},
+                        {"items", {
+                            {"type", "string"},
+                            {"enum", json::array({"upward", "overlap", "cord_object",
+                                                  "cord_cord", "presentation_overlap"})}}},
+                        {"description", "Optional subset of checks to run. Omit to run all."}}},
+                    {"epsilon", {
+                        {"type", "number"},
+                        {"description", "Tolerance in pixels for all checks (default: 2.0)."}}},
+                }},
+                {"required", json::array({"patch_id"})},
+            }},
+        },
+        {
+            {"name", "get_io_position"},
+            {"description",
+             "Return the pixel center (x, y) of each inlet (top edge) or outlet (bottom edge) "
+             "of an object, computed with Max's calibrated equal-spacing rule. Use instead of "
+             "hand-computing nub x positions for width/alignment work. 'index' is the logical "
+             "inlet/outlet number (matches connect_max_objects)."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"properties", {
+                    {"patch_id", {{"type", "string"},
+                                  {"description", "Patch ID containing the object"}}},
+                    {"varname",  {{"type", "string"},
+                                  {"description", "Object varname to query"}}},
+                    {"side", {
+                        {"type", "string"},
+                        {"enum", json::array({"inlet", "outlet"})},
+                        {"description", "Which edge to compute: 'inlet' (top) or "
+                                        "'outlet' (bottom)."}}},
+                }},
+                {"required", json::array({"patch_id", "varname", "side"})},
+            }},
+        },
+        {
+            {"name", "suggest_alignment"},
+            {"description",
+             "Compute the patching_rect that makes the target's chosen inlet/outlet share the "
+             "anchor nub's x (a vertical-straight patchcord). Read-only: returns the recommended "
+             "rect; apply it with set_object_attribute. 'adjust' chooses what changes - 'width' "
+             "resizes (keeps left), 'left' moves (keeps width)."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"properties", {
+                    {"patch_id", {{"type", "string"},
+                                  {"description", "Patch ID containing the objects"}}},
+                    {"anchor", {
+                        {"type", "object"},
+                        {"description", "The nub to align to (its x is the reference)."},
+                        {"properties", endpoint_props},
+                        {"required", json::array({"varname", "side", "index"})}}},
+                    {"target", {
+                        {"type", "object"},
+                        {"description", "The object to reposition/resize so its nub lands "
+                                        "on the anchor."},
+                        {"properties", endpoint_props},
+                        {"required", json::array({"varname", "side", "index"})}}},
+                    {"adjust", {
+                        {"type", "string"},
+                        {"enum", json::array({"width", "left"})},
+                        {"description", "'width' resizes (keeps left); 'left' moves (keeps width). "
+                                        "The leftmost nub and single-nub sides can only be aligned "
+                                        "by 'left'."}}},
+                }},
+                {"required", json::array({"patch_id", "anchor", "target", "adjust"})},
+            }},
+        },
+    });
 }
+// clang-format on
 
 // ============================================================================
 // Tool Dispatcher
@@ -414,6 +656,14 @@ json execute(const std::string& tool, const json& params) {
         return ToolCommon::test_mode_error();
 #else
         return execute_get_io_position(params);
+#endif
+    }
+
+    if (tool == "suggest_alignment") {
+#ifdef MAXMCP_TEST_MODE
+        return ToolCommon::test_mode_error();
+#else
+        return execute_suggest_alignment(params);
 #endif
     }
 

--- a/src/utils/format_util.h
+++ b/src/utils/format_util.h
@@ -1,0 +1,36 @@
+/**
+    @file format_util.h
+    MaxMCP - Small numeric-to-string helpers for finding/rationale text
+
+    Header-only formatting helpers shared by the layout tools (layout_checks,
+    io_geometry) so coordinate/area strings render consistently in one place
+    instead of being duplicated per translation unit.
+
+    @ingroup maxmcp
+*/
+
+#ifndef FORMAT_UTIL_H
+#define FORMAT_UTIL_H
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+namespace fmtutil {
+
+// One-decimal coordinate, e.g. "876.8" — the precision used in layout findings
+// and alignment rationales, without dumping full double precision.
+inline std::string fmt1(double v) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.1f", v);
+    return buf;
+}
+
+// Rounded integer string, for areas and overlap-region bounds.
+inline std::string fmti(double v) {
+    return std::to_string(static_cast<long>(std::llround(v)));
+}
+
+}  // namespace fmtutil
+
+#endif  // FORMAT_UTIL_H

--- a/src/utils/io_geometry.cpp
+++ b/src/utils/io_geometry.cpp
@@ -11,6 +11,8 @@
 
 #include "io_geometry.h"
 
+#include "format_util.h"
+
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -79,6 +81,76 @@ std::vector<IoPosition> io_positions(const Rect& rect, int logical_count, IoSide
         p.index += 1;  // shift 0..n-2 back onto logical indices 1..n-1
     }
     return positions;
+}
+
+AlignmentResult recommend_alignment_rect(const Rect& target_rect, int target_logical_count,
+                                         IoSide side, int target_index, bool draw_first_in,
+                                         const std::string& maxclass, double anchor_x,
+                                         AlignAdjust adjust) {
+    if (target_index < 0 || target_index >= target_logical_count) {
+        return {false,
+                {},
+                "target index " + std::to_string(target_index) + " out of range (count " +
+                    std::to_string(target_logical_count) + ")"};
+    }
+
+    // Map the logical index onto the visible-nub frame (drawfirstin correction):
+    // an undrawn first inlet shifts logical indices 1..n-1 onto visible 0..n-2.
+    const bool undrawn_first = (side == IoSide::Inlet) && !draw_first_in;
+    int visual_count = target_logical_count;
+    int visual_index = target_index;
+    if (undrawn_first) {
+        if (target_index == 0) {
+            return {false, {}, "target inlet 0 is not drawn (drawfirstin); it has no position"};
+        }
+        visual_count = target_logical_count - 1;
+        visual_index = target_index - 1;
+    }
+
+    const IoCalibration cal = io_calibration_for(maxclass);
+    const double left = target_rect.origin.x;
+    const double w = target_rect.width;
+
+    double new_left = left;
+    double new_width = w;
+
+    if (visual_count == 1) {
+        // Single nub: x = left + single_inset, independent of width.
+        if (adjust == AlignAdjust::Width) {
+            return {false, {}, "a single nub cannot be aligned by width; use adjust=\"left\""};
+        }
+        new_left = anchor_x - cal.single_inset;
+    } else {
+        // x_i = left + edge + (w - 2*edge) * vi/(vc-1)
+        const double edge = cal.edge_inset;
+        const double frac = static_cast<double>(visual_index) / (visual_count - 1);
+        if (adjust == AlignAdjust::Left) {
+            new_left = anchor_x - edge - (w - 2 * edge) * frac;
+        } else {  // Width: keep left, solve for the width that lands nub vi on anchor_x.
+            if (visual_index == 0) {
+                return {
+                    false, {}, "the leftmost nub cannot be aligned by width; use adjust=\"left\""};
+            }
+            // anchor_x = left + edge + (new_width - 2*edge) * vi/(vc-1)
+            new_width = 2 * edge + (anchor_x - left - edge) * (visual_count - 1) / visual_index;
+            if (new_width <= 0.0) {
+                return {false,
+                        {},
+                        "solved width " + fmtutil::fmt1(new_width) +
+                            " is non-positive; the anchor is left of where this nub can reach"};
+            }
+        }
+    }
+
+    const Rect result{new_left, target_rect.origin.y, new_width, target_rect.height};
+    const std::string nub =
+        ((side == IoSide::Inlet) ? "inlet" : "outlet") + std::to_string(target_index);
+    std::string reason = nub + " x must equal " + fmtutil::fmt1(anchor_x) + "; ";
+    reason +=
+        (adjust == AlignAdjust::Width)
+            ? "with left=" + fmtutil::fmt1(left) + " -> width=" + fmtutil::fmt1(new_width)
+            : "with width=" + fmtutil::fmt1(new_width) + " -> left=" + fmtutil::fmt1(new_left);
+    return {true, result, reason};
 }
 
 }  // namespace geometry

--- a/src/utils/io_geometry.h
+++ b/src/utils/io_geometry.h
@@ -117,6 +117,63 @@ std::vector<IoPosition> compute_io_positions(const Rect& rect, int visual_count,
 std::vector<IoPosition> io_positions(const Rect& rect, int logical_count, IoSide side,
                                      bool draw_first_in, const std::string& maxclass);
 
+// ============================================================================
+// Alignment (inverse placement) — for suggest_alignment
+// ============================================================================
+
+/**
+ * @brief Which dimension of the target's rect to change to achieve alignment.
+ *
+ * @c Width keeps the left edge and resizes; @c Left keeps the width and shifts
+ * the object horizontally.
+ */
+enum class AlignAdjust { Width, Left };
+
+/**
+ * @brief Result of an alignment computation: either a recommended rect or a
+ *        reason it could not be solved.
+ *
+ * @c ok distinguishes the two: when true, @c rect is the recommended
+ * patching_rect; when false, @c reason explains why (e.g. the leftmost nub
+ * cannot be moved by width). @c reason also carries the human-readable rationale
+ * on success.
+ */
+struct AlignmentResult {
+    bool ok;
+    Rect rect;
+    std::string reason;
+};
+
+/**
+ * @brief Solve for a target rect so one of its nubs lands at a given x.
+ *
+ * Inverse of the placement rule: returns the patching_rect that puts the
+ * target's @p target_index nub (on @p side) at x == @p anchor_x, changing only
+ * the dimension named by @p adjust (Width keeps left; Left keeps width). The
+ * rect's y and height, and the dimension not being adjusted, are preserved.
+ *
+ * Indices are logical and the drawfirstin correction is applied (an undrawn
+ * first inlet shifts the visible nubs). Unsolvable cases return @c ok=false with
+ * an explanation:
+ *   - the leftmost visible nub, or a single-nub side, cannot be moved by Width;
+ *   - @p target_index is out of range or names an undrawn inlet;
+ *   - the solved width would be non-positive.
+ *
+ * @param target_rect        The target's current patching rectangle
+ * @param target_logical_count The target's logical inlet/outlet count on @p side
+ * @param side               Inlet (top edge) or Outlet (bottom edge)
+ * @param target_index       Logical index of the nub to align
+ * @param draw_first_in      Whether the target's first inlet is drawn (inlets only)
+ * @param maxclass           The target's maxclass, for calibration lookup
+ * @param anchor_x           The x the chosen nub should land on
+ * @param adjust             Whether to change width or left
+ * @return AlignmentResult with the recommended rect, or a failure reason
+ */
+AlignmentResult recommend_alignment_rect(const Rect& target_rect, int target_logical_count,
+                                         IoSide side, int target_index, bool draw_first_in,
+                                         const std::string& maxclass, double anchor_x,
+                                         AlignAdjust adjust);
+
 }  // namespace geometry
 
 #endif  // IO_GEOMETRY_H

--- a/tests/unit/test_io_geometry.cpp
+++ b/tests/unit/test_io_geometry.cpp
@@ -21,12 +21,15 @@
 
 #include <gtest/gtest.h>
 
+using geometry::AlignAdjust;
+using geometry::AlignmentResult;
 using geometry::compute_io_positions;
 using geometry::io_calibration_for;
 using geometry::io_positions;
 using geometry::IoCalibration;
 using geometry::IoPosition;
 using geometry::IoSide;
+using geometry::recommend_alignment_rect;
 using geometry::Rect;
 
 namespace {
@@ -236,4 +239,107 @@ TEST(IoCalibrationFixtures, ToggleSquareSingleNub) {
                      0.01);
     expect_positions(io_positions(rect, 1, IoSide::Outlet, true, "toggle"), {{0, 309.5, 224.0}},
                      0.01);
+}
+
+// ---------------------------------------------------------------------------
+// recommend_alignment_rect — inverse placement (suggest_alignment)
+// ---------------------------------------------------------------------------
+
+namespace {
+// Assert the recommended rect round-trips: the chosen nub lands on anchor_x.
+void expect_nub_at(const Rect& rect, int count, IoSide side, int index, bool draw_first_in,
+                   const std::string& maxclass, double anchor_x) {
+    auto pos = io_positions(rect, count, side, draw_first_in, maxclass);
+    bool found = false;
+    for (const auto& p : pos) {
+        if (p.index == index) {
+            EXPECT_NEAR(p.center.x, anchor_x, 1e-6);
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found) << "index " << index << " not present after alignment";
+}
+}  // namespace
+
+TEST(RecommendAlignment, WidthReproducesSpecExample) {
+    // Spec §4: 6-inlet target at left=453, align inlet 5 onto anchor x=669.5 by
+    // resizing -> width 226 (right - 9.5 == 669.5). Current width is irrelevant.
+    Rect target{453.0, 1180.0, 80.0, 20.0};
+    AlignmentResult r = recommend_alignment_rect(target, 6, IoSide::Inlet, 5, true, "newobj", 669.5,
+                                                 AlignAdjust::Width);
+    ASSERT_TRUE(r.ok) << r.reason;
+    EXPECT_DOUBLE_EQ(r.rect.origin.x, 453.0);
+    EXPECT_DOUBLE_EQ(r.rect.origin.y, 1180.0);
+    EXPECT_DOUBLE_EQ(r.rect.width, 226.0);
+    EXPECT_DOUBLE_EQ(r.rect.height, 20.0);
+    expect_nub_at(r.rect, 6, IoSide::Inlet, 5, true, "newobj", 669.5);
+}
+
+TEST(RecommendAlignment, LeftMovesSingleInlet) {
+    Rect target{100.0, 200.0, 50.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(target, 1, IoSide::Inlet, 0, true, "number", 300.0,
+                                                 AlignAdjust::Left);
+    ASSERT_TRUE(r.ok) << r.reason;
+    EXPECT_DOUBLE_EQ(r.rect.origin.x, 290.5);  // 300 - 9.5
+    EXPECT_DOUBLE_EQ(r.rect.width, 50.0);      // width unchanged
+    expect_nub_at(r.rect, 1, IoSide::Inlet, 0, true, "number", 300.0);
+}
+
+TEST(RecommendAlignment, LeftMovesMultiNub) {
+    Rect target{100.0, 200.0, 120.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(target, 2, IoSide::Inlet, 1, true, "newobj", 500.0,
+                                                 AlignAdjust::Left);
+    ASSERT_TRUE(r.ok) << r.reason;
+    EXPECT_DOUBLE_EQ(r.rect.width, 120.0);  // width unchanged
+    expect_nub_at(r.rect, 2, IoSide::Inlet, 1, true, "newobj", 500.0);
+}
+
+TEST(RecommendAlignment, WidthCannotMoveLeftmostNub) {
+    Rect target{100.0, 200.0, 120.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(target, 4, IoSide::Inlet, 0, true, "newobj", 300.0,
+                                                 AlignAdjust::Width);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.reason.find("leftmost"), std::string::npos);
+}
+
+TEST(RecommendAlignment, WidthCannotMoveSingleNub) {
+    Rect target{100.0, 200.0, 50.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(target, 1, IoSide::Outlet, 0, true, "number",
+                                                 300.0, AlignAdjust::Width);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.reason.find("single nub"), std::string::npos);
+}
+
+TEST(RecommendAlignment, WidthRejectsNonPositiveSolution) {
+    // anchor far left of where inlet 1 can reach -> solved width <= 0.
+    Rect target{100.0, 200.0, 120.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(target, 2, IoSide::Inlet, 1, true, "newobj", 50.0,
+                                                 AlignAdjust::Width);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.reason.find("non-positive"), std::string::npos);
+}
+
+TEST(RecommendAlignment, IndexOutOfRangeFails) {
+    Rect target{100.0, 200.0, 120.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(target, 2, IoSide::Inlet, 5, true, "newobj", 300.0,
+                                                 AlignAdjust::Left);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.reason.find("out of range"), std::string::npos);
+}
+
+TEST(RecommendAlignment, DrawfirstinUndrawnInletZeroFails) {
+    Rect target{100.0, 200.0, 120.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(
+        target, 3, IoSide::Inlet, 0, /*draw_first_in=*/false, "x", 300.0, AlignAdjust::Left);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.reason.find("not drawn"), std::string::npos);
+}
+
+TEST(RecommendAlignment, DrawfirstinRenumberedNubAligns) {
+    // 3 logical inlets, first undrawn -> visible nubs at logical 1,2. Align nub 2.
+    Rect target{100.0, 200.0, 120.0, 22.0};
+    AlignmentResult r = recommend_alignment_rect(
+        target, 3, IoSide::Inlet, 2, /*draw_first_in=*/false, "x", 400.0, AlignAdjust::Left);
+    ASSERT_TRUE(r.ok) << r.reason;
+    expect_nub_at(r.rect, 3, IoSide::Inlet, 2, false, "x", 400.0);
 }

--- a/tests/unit/test_tool_routing.cpp
+++ b/tests/unit/test_tool_routing.cpp
@@ -238,7 +238,7 @@ TEST_F(MCPServerRoutingTest, ToolsListReturnsAllTools) {
 
     auto& tools = response["result"]["tools"];
     ASSERT_TRUE(tools.is_array());
-    EXPECT_EQ(tools.size(), 28) << "tools/list should return all 28 tools";
+    EXPECT_EQ(tools.size(), 29) << "tools/list should return all 29 tools";
 }
 
 TEST_F(MCPServerRoutingTest, ToolsListResponseFormat) {


### PR DESCRIPTION
## 概要

レイアウト整理で頻出する「この outlet を、この inlet と同じ x に縦一直線で揃えたい」をサーバ側の逆算で一発解決する read-only MCP ツール `suggest_alignment` を追加します（Issue #76 Step 4）。AI が `get_io_position`（Step 3）で anchor の x を得たあと target の rect を手計算していた工程を置き換え、「LLM から幾何計算を奪う」#76 の目的を配置プリミティブに広げます。

ツール数: **28 → 29**。

## 設計

- **必須パラメータ `adjust`**（既定なし）: `"width"`（left 固定でリサイズ）/ `"left"`（width 固定で移動）。左端 nub・単一 nub は width で動かせないため、その場合は `adjust="left"` を促すエラーを返す。
- **read-only**: 推奨 `patching_rect` を返すのみ。適用は AI が `set_object_attribute` で行う。
- **pure/glue 分離**（#80 で確立したパターン）:
  - 純粋逆算 `recommend_alignment_rect`（`src/utils/io_geometry.{h,cpp}`）— Max 非依存。順方向の配置則を反転。drawfirstin 補正、単一/左端 nub の width 不可・w<=0・index 範囲外をエラー化。
  - グルー（`src/tools/layout_tools.cpp`）— anchor の x は既存 `io_positions` から index 一致検索で取得し、main thread へ defer。
- **共有ヘッダ** `src/utils/format_util.h`（新規）: `fmt1`/`fmti` を `namespace fmtutil` に抽出し `layout_checks.cpp` の重複を解消。
- スキーマは `// clang-format off/on` で手整形し、anchor/target の重複を `endpoint_props` 共有変数で DRY 化。

## 入出力

入力: `{patch_id, anchor:{varname,side,index}, target:{varname,side,index}, adjust:"width"|"left"}`
出力: `{anchor:{...,x}, target:{...}, adjust, recommended_patching_rect:[x,y,w,h], rationale}`

## テスト / 検証

- **ユニット**: `test_io_geometry.cpp` に逆算9件（仕様例 width=226 再現、left 移動、単一/左端 nub の width エラー、drawfirstin 再番号、w<=0、index 範囲外）。`test_tool_routing.cpp` 集約数 28→29。`./build.sh --test` で **198 テスト全パス**。
- **実機（Max 9）**: 全29ツールのチェックリストを通し、#29〜#29d を含め全合格。
  - `adjust="width"`: 適用後に target outlet の x が anchor x に**完全一致**。
  - `adjust="left"`: left のみ変化・width 不変、適用後に両 nub の x が一致。
  - エラー系（左端/単一 nub の width、未知 varname（anchor/target）、bad side·adjust、index 範囲外）と **read-only 維持**を確認。

## レビュー

`pr-review-toolkit:code-reviewer` 通過。指摘（スキーマ手整形による 100 文字超過 5 行）を文字列リテラル分割で修正し、再確認で解消・新規問題なしを確認済み。

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)