### PR TITLE
refactor(tools): extract defer→wait→unwrap tail into run_deferred helper

### DIFF
--- a/docs/integration-test-checklist.md
+++ b/docs/integration-test-checklist.md
@@ -35,9 +35,13 @@
 | 8  | `get_object_attribute` | Get patching_rect                 | Returns [x, y, width, height] array       | [ ]  |
 | 9  | `get_object_value`     | Get number box value              | Returns number (default: 0)               | [ ]  |
 | 10 | `get_object_io_info`   | Get IO info for cycle~            | inlet_count: 2, outlet_count: 1           | [ ]  |
+| 10a| `get_object_io_info`   | Unknown `varname`                 | Plain `Object not found: <varname>` error (not double-wrapped) | [ ]  |
 | 11 | `get_object_hidden`    | Get hidden state                  | hidden: false (default)                   | [ ]  |
+| 11a| `get_object_hidden`    | Unknown `varname`                 | Plain `Object not found: <varname>` error (not double-wrapped) | [ ]  |
 | 12 | `set_object_hidden`    | Hide then unhide                  | hidden: true then hidden: false           | [ ]  |
+| 12a| `set_object_hidden`    | Unknown `varname`                 | Plain `Object not found: <varname>` error (not double-wrapped) | [ ]  |
 | 13 | `redraw_object`        | Force redraw                      | success: true                             | [ ]  |
+| 13a| `redraw_object`        | Unknown `varname`                 | Plain `Object not found: <varname>` error (not double-wrapped) | [ ]  |
 | 14 | `replace_object_text`  | Change `cycle~ 440` to `cycle~ 880` | old_text/new_text returned correctly   | [ ]  |
 | 15 | `assign_varnames`      | Assign varname to unnamed object  | assigned: 1, varname set                  | [ ]  |
 
@@ -152,3 +156,4 @@
 - Full hierarchy testing requires a patch containing subpatchers (p, poly~, bpatcher, etc.)
 - `validate_layout` is read-only (never moves objects or cords); it only reports findings. The intended workflow is validate → fix → re-validate until `clean: true`
 - `validate_layout` cord endpoints use the patchline's real start/end points (`jpatchline_get_startpoint/endpoint`); per-inlet/outlet pixel positions (`get_io_position`) are a separate future tool (see `docs/layout-validation-tools-spec.md`)
+- All 26 deferred tools share the `ToolCommon::run_deferred` helper (#89). It reproduces three response envelopes — raw (e.g. `add_max_object`), always-wrapped `{"result": ...}` (e.g. `get_objects_in_patch`), and error-passthrough-on-success (e.g. `get_object_io_info`, `redraw_object`). The unknown-`varname` rows above (10a–13a, 28d, and the unknown-`varname` cases of 29d/30f) exercise the passthrough branch — the error is raised inside the deferred callback, so it must surface as a plain `error` object, never wrapped inside `result`. By contrast, the parameter-validation errors (28e, and the invalid `side`/`adjust`/`mode` cases of 29d/30f) are rejected *before* deferral, so they never reach the wrap logic

--- a/src/tools/connection_tools.cpp
+++ b/src/tools/connection_tools.cpp
@@ -453,18 +453,9 @@ static json execute_connect_max_objects(const json& params) {
     auto* data =
         new t_connection_data(patch, src_varname, outlet, dst_varname, inlet, deferred_result);
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)connect_objects_deferred, gensym("connect_objects"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("connecting objects");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)connect_objects_deferred, "connect_objects",
+                                    data, ToolCommon::DEFAULT_DEFER_TIMEOUT, "connecting objects",
+                                    ToolCommon::DeferredWrap::Raw);
 }
 
 /**
@@ -492,18 +483,9 @@ static json execute_disconnect_max_objects(const json& params) {
     auto* data =
         new t_connection_data(patch, src_varname, outlet, dst_varname, inlet, deferred_result);
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)disconnect_objects_deferred, gensym("disconnect_objects"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("disconnecting objects");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)disconnect_objects_deferred,
+                                    "disconnect_objects", data, ToolCommon::DEFAULT_DEFER_TIMEOUT,
+                                    "disconnecting objects", ToolCommon::DeferredWrap::Raw);
 }
 
 /**
@@ -526,18 +508,9 @@ static json execute_get_patchlines(const json& params) {
     auto* deferred_result = new DeferredResult();
     auto* data = new t_get_patchlines_data{patch, mode, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_patchlines_deferred, gensym("get_patchlines"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::HEAVY_OPERATION_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting patchlines");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_patchlines_deferred, "get_patchlines", data,
+                                    ToolCommon::HEAVY_OPERATION_TIMEOUT, "getting patchlines",
+                                    ToolCommon::DeferredWrap::Always);
 }
 
 /**
@@ -586,19 +559,10 @@ static json execute_set_patchline_midpoints(const json& params) {
     auto* data = new t_set_midpoints_data(patch, src_varname, outlet, dst_varname, inlet,
                                           deferred_result, std::move(coords));
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)set_patchline_midpoints_deferred, gensym("set_patchline_midpoints"), 1,
-          &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("setting patchline midpoints");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)set_patchline_midpoints_deferred,
+                                    "set_patchline_midpoints", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT,
+                                    "setting patchline midpoints", ToolCommon::DeferredWrap::Raw);
 }
 
 #endif  // MAXMCP_TEST_MODE

--- a/src/tools/hierarchy_tools.cpp
+++ b/src/tools/hierarchy_tools.cpp
@@ -175,22 +175,9 @@ json execute(const std::string& tool, const json& params) {
         DeferredResult* deferred_result = new DeferredResult();
         t_get_parent_data* data = new t_get_parent_data{patch, deferred_result};
 
-        t_atom a;
-        atom_setobj(&a, data);
-        defer(patch, (method)get_parent_deferred, gensym("get_parent"), 1, &a);
-
-        if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-            delete deferred_result;
-            return ToolCommon::timeout_error("getting parent patcher");
-        }
-
-        json result = deferred_result->result;
-        delete deferred_result;
-
-        if (result.contains("error")) {
-            return result;
-        }
-        return {{"result", result}};
+        return ToolCommon::run_deferred(patch, (method)get_parent_deferred, "get_parent", data,
+                                        ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting parent patcher",
+                                        ToolCommon::DeferredWrap::OnSuccess);
 
     } else if (tool == "get_subpatchers") {
         std::string patch_id = params.value("patch_id", "");
@@ -207,18 +194,9 @@ json execute(const std::string& tool, const json& params) {
         DeferredResult* deferred_result = new DeferredResult();
         t_get_subpatchers_data* data = new t_get_subpatchers_data{patch, deferred_result};
 
-        t_atom a;
-        atom_setobj(&a, data);
-        defer(patch, (method)get_subpatchers_deferred, gensym("get_subpatchers"), 1, &a);
-
-        if (!deferred_result->wait_for(ToolCommon::HEAVY_OPERATION_TIMEOUT)) {
-            delete deferred_result;
-            return ToolCommon::timeout_error("getting subpatchers");
-        }
-
-        json result = deferred_result->result;
-        delete deferred_result;
-        return {{"result", result}};
+        return ToolCommon::run_deferred(patch, (method)get_subpatchers_deferred, "get_subpatchers",
+                                        data, ToolCommon::HEAVY_OPERATION_TIMEOUT,
+                                        "getting subpatchers", ToolCommon::DeferredWrap::Always);
     }
 
     // Unknown tool - return nullptr to signal not handled

--- a/src/tools/layout_tools.cpp
+++ b/src/tools/layout_tools.cpp
@@ -267,18 +267,9 @@ static json execute_validate_layout(const json& params) {
     auto* data =
         new t_validate_layout_data{patch, options, std::move(scope_varnames), deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)validate_layout_deferred, gensym("validate_layout"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::HEAVY_OPERATION_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("validating layout");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)validate_layout_deferred, "validate_layout",
+                                    data, ToolCommon::HEAVY_OPERATION_TIMEOUT, "validating layout",
+                                    ToolCommon::DeferredWrap::Always);
 }
 
 /**
@@ -349,22 +340,9 @@ static json execute_get_io_position(const json& params) {
     auto* deferred_result = new DeferredResult();
     auto* data = new t_get_io_position_data{patch, varname, side, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_io_position_deferred, gensym("get_io_position"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting io position");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-
-    if (result.contains("error")) {
-        return result;
-    }
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_io_position_deferred, "get_io_position",
+                                    data, ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting io position",
+                                    ToolCommon::DeferredWrap::OnSuccess);
 }
 
 // Resolve one alignment endpoint to the pixel x of its nub. On failure, writes a
@@ -519,22 +497,9 @@ static json execute_suggest_alignment(const json& params) {
     auto* deferred_result = new DeferredResult();
     auto* data = new t_suggest_alignment_data{patch, anchor, target, adjust, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)suggest_alignment_deferred, gensym("suggest_alignment"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("suggesting alignment");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-
-    if (result.contains("error")) {
-        return result;
-    }
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)suggest_alignment_deferred, "suggest_alignment",
+                                    data, ToolCommon::DEFAULT_DEFER_TIMEOUT, "suggesting alignment",
+                                    ToolCommon::DeferredWrap::OnSuccess);
 }
 
 // Map an align/distribute mode string to the enum. Returns false on an unknown
@@ -630,22 +595,9 @@ static json execute_align_objects(const json& params) {
     auto* deferred_result = new DeferredResult();
     auto* data = new t_align_objects_data{patch, varnames, mode, mode_str, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)align_objects_deferred, gensym("align_objects"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("aligning objects");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-
-    if (result.contains("error")) {
-        return result;
-    }
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)align_objects_deferred, "align_objects", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "aligning objects",
+                                    ToolCommon::DeferredWrap::OnSuccess);
 }
 
 #endif  // MAXMCP_TEST_MODE

--- a/src/tools/object_tools.cpp
+++ b/src/tools/object_tools.cpp
@@ -897,18 +897,9 @@ json execute_add_max_object(const json& params) {
     auto* data = new t_add_object_data{patch,   obj_type,  x,          y,
                                        varname, arguments, attributes, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)add_object_deferred, gensym("add_object"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("creating object");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)add_object_deferred, "add_object", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "creating object",
+                                    ToolCommon::DeferredWrap::Raw);
 }
 
 json execute_remove_max_object(const json& params) {
@@ -928,18 +919,9 @@ json execute_remove_max_object(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     auto* data = new t_remove_object_data{patch, varname, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)remove_object_deferred, gensym("remove_object"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("removing object");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)remove_object_deferred, "remove_object", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "removing object",
+                                    ToolCommon::DeferredWrap::Raw);
 }
 
 json execute_get_objects_in_patch(const json& params) {
@@ -959,18 +941,10 @@ json execute_get_objects_in_patch(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     t_get_objects_data* data = new t_get_objects_data{patch, mode, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_objects_deferred, gensym("get_objects"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::HEAVY_OPERATION_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("waiting for patch object list");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_objects_deferred, "get_objects", data,
+                                    ToolCommon::HEAVY_OPERATION_TIMEOUT,
+                                    "waiting for patch object list",
+                                    ToolCommon::DeferredWrap::Always);
 }
 
 json execute_set_object_attribute(const json& params) {
@@ -998,18 +972,9 @@ json execute_set_object_attribute(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     auto* data = new t_set_attribute_data{patch, varname, attribute, value, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)set_attribute_deferred, gensym("set_attribute"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("setting attribute");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)set_attribute_deferred, "set_attribute", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "setting attribute",
+                                    ToolCommon::DeferredWrap::Raw);
 }
 
 json execute_get_object_attribute(const json& params) {
@@ -1031,18 +996,9 @@ json execute_get_object_attribute(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     auto* data = new t_get_attribute_data{patch, varname, attribute, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_attribute_deferred, gensym("get_attribute"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting attribute");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)get_attribute_deferred, "get_attribute", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting attribute",
+                                    ToolCommon::DeferredWrap::Raw);
 }
 
 json execute_get_object_io_info(const json& params) {
@@ -1062,22 +1018,9 @@ json execute_get_object_io_info(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     t_get_io_info_data* data = new t_get_io_info_data{patch, varname, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_io_info_deferred, gensym("get_io_info"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting I/O info");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-
-    if (result.contains("error")) {
-        return result;
-    }
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_io_info_deferred, "get_io_info", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting I/O info",
+                                    ToolCommon::DeferredWrap::OnSuccess);
 }
 
 json execute_get_object_hidden(const json& params) {
@@ -1097,22 +1040,9 @@ json execute_get_object_hidden(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     t_get_hidden_data* data = new t_get_hidden_data{patch, varname, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_hidden_deferred, gensym("get_hidden"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting hidden state");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-
-    if (result.contains("error")) {
-        return result;
-    }
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_hidden_deferred, "get_hidden", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting hidden state",
+                                    ToolCommon::DeferredWrap::OnSuccess);
 }
 
 json execute_set_object_hidden(const json& params) {
@@ -1138,22 +1068,9 @@ json execute_set_object_hidden(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     t_set_hidden_data* data = new t_set_hidden_data{patch, varname, hidden, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)set_hidden_deferred, gensym("set_hidden"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("setting hidden state");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-
-    if (result.contains("error")) {
-        return result;
-    }
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)set_hidden_deferred, "set_hidden", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "setting hidden state",
+                                    ToolCommon::DeferredWrap::OnSuccess);
 }
 
 json execute_redraw_object(const json& params) {
@@ -1173,22 +1090,9 @@ json execute_redraw_object(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     t_redraw_data* data = new t_redraw_data{patch, varname, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)redraw_deferred, gensym("redraw"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("redrawing object");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-
-    if (result.contains("error")) {
-        return result;
-    }
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)redraw_deferred, "redraw", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "redrawing object",
+                                    ToolCommon::DeferredWrap::OnSuccess);
 }
 
 json execute_replace_object_text(const json& params) {
@@ -1210,18 +1114,9 @@ json execute_replace_object_text(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     auto* data = new t_replace_text_data{patch, varname, new_text, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)replace_object_text_deferred, gensym("replace_object_text"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("replacing object text");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)replace_object_text_deferred,
+                                    "replace_object_text", data, ToolCommon::DEFAULT_DEFER_TIMEOUT,
+                                    "replacing object text", ToolCommon::DeferredWrap::Raw);
 }
 
 json execute_assign_varnames(const json& params) {
@@ -1270,18 +1165,9 @@ json execute_assign_varnames(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     auto* data = new t_assign_varnames_data{patch, assignments, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)assign_varnames_deferred, gensym("assign_varnames"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::HEAVY_OPERATION_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("assigning varnames");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)assign_varnames_deferred, "assign_varnames",
+                                    data, ToolCommon::HEAVY_OPERATION_TIMEOUT, "assigning varnames",
+                                    ToolCommon::DeferredWrap::Raw);
 }
 
 json execute_get_object_value(const json& params) {
@@ -1301,18 +1187,9 @@ json execute_get_object_value(const json& params) {
     auto* deferred_result = new ToolCommon::DeferredResult();
     auto* data = new t_get_value_data{patch, varname, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_value_deferred, gensym("get_value"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting object value");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return result;
+    return ToolCommon::run_deferred(patch, (method)get_value_deferred, "get_value", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting object value",
+                                    ToolCommon::DeferredWrap::Raw);
 }
 
 #endif  // MAXMCP_TEST_MODE

--- a/src/tools/state_tools.cpp
+++ b/src/tools/state_tools.cpp
@@ -155,18 +155,9 @@ static json execute_get_patch_lock_state(const json& params) {
     DeferredResult* deferred_result = new DeferredResult();
     t_get_lock_state_data* data = new t_get_lock_state_data{patch, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_lock_state_deferred, gensym("get_lock_state"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting lock state");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_lock_state_deferred, "get_lock_state", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting lock state",
+                                    ToolCommon::DeferredWrap::Always);
 }
 
 static json execute_set_patch_lock_state(const json& params) {
@@ -190,18 +181,9 @@ static json execute_set_patch_lock_state(const json& params) {
     DeferredResult* deferred_result = new DeferredResult();
     t_set_lock_state_data* data = new t_set_lock_state_data{patch, locked, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)set_lock_state_deferred, gensym("set_lock_state"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("setting lock state");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)set_lock_state_deferred, "set_lock_state", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "setting lock state",
+                                    ToolCommon::DeferredWrap::Always);
 }
 
 static json execute_get_patch_dirty(const json& params) {
@@ -219,18 +201,9 @@ static json execute_get_patch_dirty(const json& params) {
     DeferredResult* deferred_result = new DeferredResult();
     t_get_dirty_data* data = new t_get_dirty_data{patch, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_dirty_deferred, gensym("get_dirty"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("getting dirty state");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_dirty_deferred, "get_dirty", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT, "getting dirty state",
+                                    ToolCommon::DeferredWrap::Always);
 }
 
 #endif  // MAXMCP_TEST_MODE

--- a/src/tools/tool_common.h
+++ b/src/tools/tool_common.h
@@ -403,4 +403,95 @@ inline std::string get_patch_id(const json& params) {
 
 }  // namespace ToolCommon
 
+// ============================================================================
+// Deferred Executor Helper (Max SDK only)
+// ============================================================================
+//
+// run_deferred() consolidates the defer -> wait_for -> unwrap tail shared by
+// every tool executor. It touches Max SDK symbols (defer/gensym/atom_setobj),
+// so it is excluded from MAXMCP_TEST_MODE builds, where the executors that
+// would instantiate it are replaced by stubs.
+//
+// This block self-includes "ext.h" (rather than relying on include order in
+// each .cpp) and is placed last so the Max SDK macros cannot leak into the
+// pure definitions above.
+// ============================================================================
+
+#ifndef MAXMCP_TEST_MODE
+
+#include "ext.h"
+
+namespace ToolCommon {
+
+/**
+ * How run_deferred() shapes a successful callback result.
+ *
+ * Each mode mirrors a pre-existing executor tail so the refactor preserves
+ * behavior exactly:
+ *   - Raw:       return the result unchanged.
+ *   - Always:    always wrap success as {"result": result}.
+ *   - OnSuccess: pass {"error": ...} through unchanged, otherwise wrap.
+ */
+enum class DeferredWrap {
+    Raw,
+    Always,
+    OnSuccess,
+};
+
+/**
+ * Defer a payload to the Max main thread, wait for the callback, and return
+ * the unwrapped result.
+ *
+ * Ownership: the callback owns @p data and deletes it (via COMPLETE_DEFERRED);
+ * this helper owns only the DeferredResult and deletes it after the wait. On
+ * timeout the DeferredResult is deleted and a timeout_error is returned, while
+ * @p data is intentionally left for the still-pending callback. This preserves
+ * the existing (and existing-races-on-timeout) ownership split.
+ *
+ * @tparam DataT  Deferred data struct; must expose a `deferred_result` member.
+ * @param patch   Owning patch (defer target object).
+ * @param cb      Deferred callback, cast to method by the caller.
+ * @param name    gensym name for the deferred message.
+ * @param data    Heap-allocated payload; ownership passes to the callback.
+ * @param timeout Maximum time to wait for the callback.
+ * @param action  Description used in the timeout error message.
+ * @param wrap    How to shape a successful result.
+ */
+template <typename DataT>
+json run_deferred(t_maxmcp* patch, method cb, const char* name, DataT* data,
+                  std::chrono::milliseconds timeout, const char* action,
+                  DeferredWrap wrap = DeferredWrap::Raw) {
+    // Capture before defer(): the callback may delete `data` once it runs.
+    DeferredResult* deferred_result = data->deferred_result;
+
+    t_atom a;
+    atom_setobj(&a, data);
+    defer(patch, cb, gensym(name), 1, &a);
+
+    if (!deferred_result->wait_for(timeout)) {
+        delete deferred_result;
+        return timeout_error(action);
+    }
+
+    json result = deferred_result->result;
+    delete deferred_result;
+
+    switch (wrap) {
+    case DeferredWrap::Always:
+        return {{"result", result}};
+    case DeferredWrap::OnSuccess:
+        if (result.contains("error")) {
+            return result;
+        }
+        return {{"result", result}};
+    case DeferredWrap::Raw:
+    default:
+        return result;
+    }
+}
+
+}  // namespace ToolCommon
+
+#endif  // MAXMCP_TEST_MODE
+
 #endif  // TOOL_COMMON_H

--- a/src/tools/utility_tools.cpp
+++ b/src/tools/utility_tools.cpp
@@ -289,18 +289,10 @@ static json execute_get_avoid_rect_position(const json& params) {
     auto* data =
         new t_get_position_data{patch, width, height, has_near, near_x, near_y, deferred_result};
 
-    t_atom a;
-    atom_setobj(&a, data);
-    defer(patch, (method)get_position_deferred, gensym("get_position"), 1, &a);
-
-    if (!deferred_result->wait_for(ToolCommon::DEFAULT_DEFER_TIMEOUT)) {
-        delete deferred_result;
-        return ToolCommon::timeout_error("waiting for position calculation");
-    }
-
-    json result = deferred_result->result;
-    delete deferred_result;
-    return {{"result", result}};
+    return ToolCommon::run_deferred(patch, (method)get_position_deferred, "get_position", data,
+                                    ToolCommon::DEFAULT_DEFER_TIMEOUT,
+                                    "waiting for position calculation",
+                                    ToolCommon::DeferredWrap::Always);
 }
 
 #endif  // MAXMCP_TEST_MODE


### PR DESCRIPTION
## 概要

各 MCP ツールの executor 末尾に**26箇所**ほぼ同型で並んでいた「defer → wait_for → unwrap」の定型コードを、`tool_common.h` に追加した共有テンプレート `ToolCommon::run_deferred()` に集約しました。

Closes #89

## 設計

既存コードには3つの末尾バリエーションがあり、`DeferredWrap` ポリシーで**挙動を厳密に保持**しています:

| モード | 既存の末尾 | 該当数 |
|--------|-----------|--------|
| `Raw` | `return result;`（生で返す） | 10 |
| `Always` | `return {{"result", result}};`（常にラップ） | 8 |
| `OnSuccess` | `if (result.contains("error")) return result; return {{"result", result}};`（error 透過＋ラップ） | 8 |

### 所有権・スレッド安全性

- コールバック側（`COMPLETE_DEFERRED`）が `data` を delete し、ヘルパーは `deferred_result` のみ delete する分担を維持
- `data->deferred_result` を `defer()` **前**にキャプチャ（コールバックが data を delete した後に触れない）
- timeout 時は `deferred_result` のみ delete し `data` はコールバックに委ねる（既存挙動。既知の timeout race も本 PR のスコープ外として意図的に不変）

### テストビルド対応

`run_deferred` は Max SDK の `defer`/`gensym`/`atom_setobj` を使うため `#ifndef MAXMCP_TEST_MODE` でガードし、`tool_common.h` 末尾で `ext.h` を自前 include。テストビルドでは executor 本体がスタブに置き換わるためテンプレートは未インスタンス化。

## 差分

- 7ファイル変更、`172 insertions(+), 345 deletions(-)`（コードの正味削減）
- ドキュメント: 統合テストチェックリストに error-passthrough 回帰行（10a–13a）と run_deferred の応答エンベロープ説明を追加

## 検証

- ✅ `./build.sh --test` 全212テストパス
- ✅ clang-format 適用済み
- ✅ code-reviewer エージェントレビュー: critical/important 問題なし
- ✅ **Max 9 実機テスト: 全30ツール + 追加4行（10a–13a）を実行し全PASS**
  - Raw / Always / OnSuccess の3エンベロープが従来どおりの応答形であることを確認
  - OnSuccess のエラー透過ブランチ（不正 varname 時に素のエラーが返り二重ラップされない）を object/hierarchy/layout 系で全数確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)